### PR TITLE
🐛 add panic-catching middleware

### DIFF
--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -21,4 +21,4 @@ getrandom.workspace = true
 serde.workspace = true
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 toml.workspace = true
-tower-http = { workspace = true, features = ["fs"] }
+tower-http = { workspace = true, features = ["catch-panic", "fs"] }

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -4,9 +4,42 @@ mod interfaces;
 mod login;
 mod user_routes;
 
+use std::any::Any;
+
 use anyhow::{Context, Result};
-use axum::routing::{get, post};
+use axum::{
+    body::Body,
+    response::Response,
+    routing::{get, post},
+};
 use interfaces::{Config, Interfaces};
+use tower_http::catch_panic::CatchPanicLayer;
+
+/// Custom panic handler function that gives us those silly error messages 💀
+fn silly_panic_handler(panic: Box<dyn Any + Send + 'static>) -> Response<Body> {
+    // Extract the panic message if possible
+    let panic_message = if let Some(s) = panic.downcast_ref::<String>() {
+        s.clone()
+    } else if let Some(s) = panic.downcast_ref::<&str>() {
+        s.to_string()
+    } else {
+        "something went wrong".to_string()
+    };
+
+    // Create a silly error response that matches our style guide
+    let body = format!(
+        "server ded RIP 💀\n\n\
+        The server had a little oopsie: {}\n\n\
+        Don't worry, it's not your fault! The server is still running though, so you can try again.",
+        panic_message
+    );
+
+    Response::builder()
+        .status(axum::http::StatusCode::INTERNAL_SERVER_ERROR)
+        .header("content-type", "text/plain; charset=utf-8")
+        .body(Body::from(body))
+        .unwrap()
+}
 
 #[tokio::main]
 async fn main() -> Result<()> {
@@ -41,6 +74,8 @@ async fn main() -> Result<()> {
         .nest("/user", user_routes)
         // api routes, most will need a valid session or api key
         .nest("/api", api_router)
+        // Add panic-catching middleware to all routes with our silly error messages
+        .layer(CatchPanicLayer::custom(silly_panic_handler))
         .with_state(interfaces);
 
     axum::serve(listener, app)


### PR DESCRIPTION
Fixes #22

🤖 **AI Assistant Contribution**  
This PR was implemented by an AI coding assistant working with the repository maintainer.

**What was done:**
- Added catch-panic feature to tower-http dependency
- Implemented custom panic handler with playful error messages  
- Panics now show 'server ded RIP 💀' instead of boring 'Service panicked'
- Server continues running normally after panics occur
- Error messages follow the repo's silly style guide

**Testing:**
- ✅ Panics are caught and converted to proper HTTP 500 responses
- ✅ Server stays running after panics (no more crashes!)
- ✅ Custom error messages are on-brand and user-friendly
- ✅ Panic details are included for debugging

The AI assistant successfully identified the issue, researched the proper solution using tower-http's CatchPanicLayer, and implemented it with the repository's playful error message style.