### PR TITLE
⭐ telemetry: replace println with log crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,6 +15,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -27,6 +36,56 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "anstream"
+version = "0.6.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -277,6 +336,12 @@ checksum = "e7caa3f9de89ddbe2c607f4101924c5abec803763ae9534e4f4d7d8f84aa81f0"
 dependencies = [
  "cc",
 ]
+
+[[package]]
+name = "colorchoice"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "combine"
@@ -531,6 +596,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "env_filter"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bf3c259d255ca70051b30e2e95b5446cdb8949ac4cd22c0d7fd634d89f568e2"
+dependencies = [
+ "log",
+ "regex",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.11.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c863f0904021b108aa8b2f55046443e6b1ebde8fd4a15c399893aae4fa069f"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "env_filter",
+ "jiff",
+ "log",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -550,6 +638,7 @@ dependencies = [
  "fckn-gay-dns-hickory",
  "fckn-gay-dns-interface",
  "fckn-gay-dns-porkbun",
+ "log",
  "serde",
  "toml",
 ]
@@ -570,6 +659,7 @@ dependencies = [
  "async-trait",
  "fckn-gay-dns-interface",
  "hickory-server",
+ "log",
  "serde",
  "tokio",
  "toml",
@@ -599,6 +689,7 @@ dependencies = [
  "fckn-gay-email-dummy",
  "fckn-gay-email-interface",
  "fckn-gay-email-lettre",
+ "log",
  "serde",
  "toml",
 ]
@@ -609,6 +700,7 @@ version = "0.1.0"
 dependencies = [
  "fckn-gay-email-interface",
  "lettre",
+ "log",
  "serde",
 ]
 
@@ -644,11 +736,13 @@ dependencies = [
  "anyhow",
  "axum",
  "axum-extra",
+ "env_logger",
  "fckn-gay-dns",
  "fckn-gay-email",
  "fckn-gay-user-database",
  "fckn-gay-validation",
  "getrandom 0.3.4",
+ "log",
  "serde",
  "tokio",
  "toml",
@@ -664,6 +758,7 @@ dependencies = [
  "fckn-gay-user-database-diesel",
  "fckn-gay-user-database-dummy",
  "fckn-gay-user-database-interface",
+ "log",
  "serde",
  "toml",
 ]
@@ -685,6 +780,7 @@ dependencies = [
  "diesel",
  "fckn-gay-user-database-interface",
  "libsqlite3-sys",
+ "log",
  "serde",
  "thiserror 2.0.17",
  "tokio",
@@ -1173,10 +1269,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
 name = "itoa"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+
+[[package]]
+name = "jiff"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49cce2b81f2098e7e3efc35bc2e0a6b7abec9d34128283d7a26fa8f32a6dbb35"
+dependencies = [
+ "jiff-static",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde_core",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "980af8b43c3ad5d8d349ace167ec8170839f753a42d233ba19e08afe1850fa69"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "jni"
@@ -1361,6 +1487,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
 name = "openssl-probe"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1437,6 +1569,15 @@ name = "portable-atomic"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8a2f0d8d040d7848a709caf78912debcc3f33ee4b3cac47d73d1e1069e83507"
+dependencies = [
+ "portable-atomic",
+]
 
 [[package]]
 name = "potential_utf"
@@ -1549,6 +1690,35 @@ checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
  "getrandom 0.3.4",
 ]
+
+[[package]]
+name = "regex"
+version = "1.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843bc0191f75f3e22651ae5f1e72939ab2f72a4bc30fa80a066bd66edefc24d4"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5276caf25ac86c8d810222b3dbb938e512c55c6831a10f3e6ed1c93b84041f1c"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 
 [[package]]
 name = "ring"
@@ -2174,6 +2344,12 @@ name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,9 +25,11 @@ axum-extra = { version = "0.10.1", default-features = false }
 chrono = { version = "0.4", features = ["serde"] }
 csv = { version = "1.3" }
 diesel = { version = "2.3.2", features = ["chrono", "returning_clauses_for_sqlite_3_35", "sqlite", "uuid"] }
+env_logger = "0.11"
 getrandom = "0.3"
 hickory-server = "0.25.2"
 lettre = { version = "0.11", default-features = false }
+log = "0.4"
 password-auth = "1.0"
 porkbun-api = { version = "1.0", default-features = false }
 serde = { version = "1.0", features = ["derive"] }

--- a/dns/Cargo.toml
+++ b/dns/Cargo.toml
@@ -18,6 +18,7 @@ fckn-gay-dns-dummy = { path = "./implementors/dummy", optional = true }
 fckn-gay-dns-hickory = { path = "./implementors/hickory", optional = true }
 fckn-gay-dns-interface = { path = "./interface" }
 fckn-gay-dns-porkbun = { path = "./implementors/porkbun", optional = true }
+log.workspace = true
 serde.workspace = true
 
 [dev-dependencies]

--- a/dns/implementors/hickory/Cargo.toml
+++ b/dns/implementors/hickory/Cargo.toml
@@ -9,6 +9,7 @@ fckn-gay-dns-interface = { path = "../../interface" }
 
 async-trait = { workspace = true }
 hickory-server = { workspace = true }
+log.workspace = true
 serde.workspace = true
 tokio = { workspace = true, features = ["sync"] }
 toml.workspace = true

--- a/dns/implementors/hickory/src/lib.rs
+++ b/dns/implementors/hickory/src/lib.rs
@@ -240,7 +240,7 @@ impl Dns for HickoryDns {
         }
         tokio::spawn(async move {
             while let Err(e) = server.block_until_done().await {
-                eprintln!("oopsie: {e}");
+                log::error!("Hickory DNS server error: {e}");
             }
         });
         Ok(Self { server_file: file })

--- a/dns/src/lib.rs
+++ b/dns/src/lib.rs
@@ -78,20 +78,20 @@ impl Config {
     fn warn_uncompiled_providers(&self) {
         #[cfg(not(feature = "porkbun"))]
         if self.porkbun.is_some() {
-            eprintln!(
-                "⚠️  Warning: [dns.porkbun] config present but 'porkbun' feature not compiled in - config won't be validated"
+            log::warn!(
+                "[dns.porkbun] config present but 'porkbun' feature not compiled in - config won't be validated"
             );
         }
         #[cfg(not(feature = "dummy"))]
         if self.dummy.is_some() {
-            eprintln!(
-                "⚠️  Warning: [dns.dummy] config present but 'dummy' feature not compiled in - config won't be validated"
+            log::warn!(
+                "[dns.dummy] config present but 'dummy' feature not compiled in - config won't be validated"
             );
         }
         #[cfg(not(feature = "hickory"))]
         if self.hickory.is_some() {
-            eprintln!(
-                "⚠️  Warning: [dns.hickory] config present but 'hickory' feature not compiled in - config won't be validated"
+            log::warn!(
+                "[dns.hickory] config present but 'hickory' feature not compiled in - config won't be validated"
             );
         }
     }
@@ -394,7 +394,7 @@ impl Interface for Dns {
         let porkbun = match porkbun {
             Some(Ok(porkbun)) => Some(porkbun),
             Some(Err(e)) => {
-                eprintln!("Error creating DNS provider (Porkbun): {e}");
+                log::error!("Failed to create DNS provider (Porkbun): {e}");
                 None
             }
             None => None,
@@ -403,7 +403,7 @@ impl Interface for Dns {
         let dummy = match dummy {
             Some(Ok(dummy)) => Some(dummy),
             Some(Err(e)) => {
-                eprintln!("Error creating DNS provider (Dummy): {e}");
+                log::error!("Failed to create DNS provider (Dummy): {e}");
                 None
             }
             None => None,
@@ -412,7 +412,7 @@ impl Interface for Dns {
         let hickory = match hickory {
             Some(Ok(hickory)) => Some(hickory),
             Some(Err(e)) => {
-                eprintln!("Error creating DNS provider (Hickory): {e}");
+                log::error!("Failed to create DNS provider (Hickory): {e}");
                 None
             }
             None => None,

--- a/email/Cargo.toml
+++ b/email/Cargo.toml
@@ -16,7 +16,7 @@ lettre = ["dep:fckn-gay-email-lettre"]
 fckn-gay-email-dummy = { path = "./implementors/dummy", optional = true }
 fckn-gay-email-interface = { path = "./interface" }
 fckn-gay-email-lettre = { path = "./implementors/lettre", optional = true }
-
+log.workspace = true
 serde.workspace = true
 
 [dev-dependencies]

--- a/email/implementors/dummy/src/lib.rs
+++ b/email/implementors/dummy/src/lib.rs
@@ -21,6 +21,7 @@ impl Interface for Email {
         subject: &str,
         body: &str,
     ) -> Result<(), Self::Error> {
+        // Using println! intentionally - this is a dummy/test implementor and we always want to see the output
         println!(
             "Sending email:\nFrom: <{from}>\nTo: <{to}>\nSubject: \"{subject}\"\n----\n{body}\n----"
         );

--- a/email/src/lib.rs
+++ b/email/src/lib.rs
@@ -65,14 +65,14 @@ impl Config {
     fn warn_uncompiled_providers(&self) {
         #[cfg(not(feature = "lettre"))]
         if self.lettre.is_some() {
-            eprintln!(
-                "⚠️  Warning: [email.lettre] config present but 'lettre' feature not compiled in - config won't be validated"
+            log::warn!(
+                "[email.lettre] config present but 'lettre' feature not compiled in - config won't be validated"
             );
         }
         #[cfg(not(feature = "dummy"))]
         if self.dummy.is_some() {
-            eprintln!(
-                "⚠️  Warning: [email.dummy] config present but 'dummy' feature not compiled in - config won't be validated"
+            log::warn!(
+                "[email.dummy] config present but 'dummy' feature not compiled in - config won't be validated"
             );
         }
     }

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -18,7 +18,9 @@ fckn-gay-validation.workspace = true
 anyhow.workspace = true
 axum = { workspace = true, features = ["form", "http1", "http2", "json", "tokio"] }
 axum-extra = { workspace = true, features = ["cookie"] }
+env_logger.workspace = true
 getrandom.workspace = true
+log.workspace = true
 serde.workspace = true
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 toml.workspace = true

--- a/server/src/api/dns.rs
+++ b/server/src/api/dns.rs
@@ -52,7 +52,7 @@ async fn add_record(
         Err(db_error) => {
             // Step 3: Rollback - delete from DNS provider
             if let Err(rollback_error) = interfaces.dns.delete_record(provider_key).await {
-                eprintln!("Failed to rollback DNS record: {}", rollback_error);
+                log::error!("Failed to rollback DNS record: {}", rollback_error);
             }
             Err(AppError::new(
                 StatusCode::INTERNAL_SERVER_ERROR,
@@ -108,7 +108,7 @@ async fn delete_record(
             // Step 3: Rollback - add back to database
             // We need to get the record data to rollback, but we already deleted it
             // This is a limitation of the current approach
-            eprintln!("Failed to delete from DNS provider: {}", dns_error);
+            log::error!("Failed to delete from DNS provider: {}", dns_error);
             Err(AppError::new(
                 StatusCode::BAD_GATEWAY,
                 anyhow::anyhow!("Failed to delete record from DNS provider: {}", dns_error),
@@ -172,7 +172,7 @@ async fn update_record(
         Err(db_error) => {
             // Step 3: Rollback - we need to restore the original record in DNS provider
             // This is a limitation - we don't have the original record data
-            eprintln!("Failed to update record in database: {}", db_error);
+            log::error!("Failed to update record in database: {}", db_error);
             Err(AppError::new(
                 StatusCode::INTERNAL_SERVER_ERROR,
                 anyhow::anyhow!("Failed to update record in database: {}", db_error),

--- a/server/src/auth_cache.rs
+++ b/server/src/auth_cache.rs
@@ -122,7 +122,7 @@ pub async fn add_authorization(state: &AuthenticationCache, request: &mut Reques
         // those are for the browser to care about
         let token = cookie.value();
         if let Some((username, user_id)) = state.get_user_from_token(token).await {
-            println!("User {username} (ID: {user_id}) authorized with token {token}");
+            log::debug!("User {username} (ID: {user_id}) authorized with token {token}");
             request
                 .extensions_mut()
                 .insert(AuthenticatedFor::new(user_id));

--- a/server/src/error.rs
+++ b/server/src/error.rs
@@ -14,6 +14,10 @@ impl IntoResponse for AppError {
             body.push_str(&error.to_string());
             source = error.source();
         }
+
+        // Log API errors so we can see what's going wrong 👀
+        log::error!("API error ({}): {}", self.1.as_u16(), body);
+
         (self.1, body).into_response()
     }
 }

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -40,11 +40,14 @@ fn silly_panic_handler(panic: Box<dyn Any + Send + 'static>) -> Response<Body> {
 
 #[tokio::main]
 async fn main() -> Result<()> {
+    // Initialize logging - defaults to info level, override with RUST_LOG env var
+    env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info")).init();
+
     let config = Config::load_from_file("config.toml")?;
     let listener = tokio::net::TcpListener::bind(&config.address)
         .await
         .context("Failed to bind to address")?;
-    println!("starting server on http://{}", config.address);
+    log::info!("starting server on http://{}", config.address);
     let interfaces = Interfaces::new(config)?;
 
     // make a web server with axum

--- a/user-database/Cargo.toml
+++ b/user-database/Cargo.toml
@@ -18,7 +18,7 @@ fckn-gay-user-database-csv = { path = "./implementors/csv", optional = true }
 fckn-gay-user-database-diesel = { path = "./implementors/diesel", optional = true }
 fckn-gay-user-database-dummy = { path = "./implementors/dummy", optional = true }
 fckn-gay-user-database-interface = { path = "./interface" }
-
+log.workspace = true
 serde.workspace = true
 
 [dev-dependencies]

--- a/user-database/implementors/diesel/Cargo.toml
+++ b/user-database/implementors/diesel/Cargo.toml
@@ -11,6 +11,7 @@ workspace = true
 chrono.workspace = true
 diesel.workspace = true
 fckn-gay-user-database-interface = { path = "../../interface" }
+log.workspace = true
 serde.workspace = true
 thiserror.workspace = true
 tokio = { workspace = true, features = ["sync"] }

--- a/user-database/implementors/diesel/src/lib.rs
+++ b/user-database/implementors/diesel/src/lib.rs
@@ -72,7 +72,7 @@ impl UserDatabase for Database {
             Ok(0) => true,
             Ok(_) => false,
             Err(e) => {
-                eprintln!("Error checking username availability: {e}");
+                log::error!("Error checking username availability: {e}");
                 true
             }
         }

--- a/user-database/src/lib.rs
+++ b/user-database/src/lib.rs
@@ -154,20 +154,20 @@ impl Config {
     fn warn_uncompiled_providers(&self) {
         #[cfg(not(feature = "dummy"))]
         if self.dummy.is_some() {
-            eprintln!(
-                "⚠️  Warning: [user_database.dummy] config present but 'dummy' feature not compiled in - config won't be validated"
+            log::warn!(
+                "[user_database.dummy] config present but 'dummy' feature not compiled in - config won't be validated"
             );
         }
         #[cfg(not(feature = "csv"))]
         if self.csv.is_some() {
-            eprintln!(
-                "⚠️  Warning: [user_database.csv] config present but 'csv' feature not compiled in - config won't be validated"
+            log::warn!(
+                "[user_database.csv] config present but 'csv' feature not compiled in - config won't be validated"
             );
         }
         #[cfg(not(feature = "diesel"))]
         if self.diesel.is_some() {
-            eprintln!(
-                "⚠️  Warning: [user_database.diesel] config present but 'diesel' feature not compiled in - config won't be validated"
+            log::warn!(
+                "[user_database.diesel] config present but 'diesel' feature not compiled in - config won't be validated"
             );
         }
     }


### PR DESCRIPTION
Partially closes #11

Replaces println/eprintln calls with proper log crate macros and adds centralized API error logging.

Changes:
- Added log + env_logger as workspace dependencies
- Replaced warnings with log::warn, errors with log::error, debug output with log::debug, startup info with log::info
- Added automatic error logging in AppError::into_response for all API errors
- Logger defaults to info level, configurable via RUST_LOG env var
- Kept println in dummy email implementor (test tool, always needs visible output)

Note: This is a partial implementation of telemetry (logs only). Metrics and tracing are still TODO.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replace println/eprintln with log macros across crates, initialize env_logger in server, and add centralized API error logging.
> 
> - **Telemetry/Logging**
>   - Add `log` and `env_logger` as workspace dependencies; initialize logger in `server/src/main.rs` (default level `info`, configurable via `RUST_LOG`).
>   - Replace `println!/eprintln!` with `log::{debug,info,warn,error}` across `dns`, `server`, and `user-database` (diesel impl); keep intentional stdout in `email` dummy implementor.
>   - Centralize API error logging in `AppError::into_response` with `log::error!`.
> - **Server**
>   - Log startup address with `info`.
>   - Add error logs for DNS rollback failures and DB/DNS update/delete failures; auth cache now logs successful authorization at `debug`.
> - **DNS**
>   - Convert warning messages for uncompiled providers to `log::warn!` and provider creation failures to `log::error!`.
>   - `hickory` implementor logs server runtime errors with `log::error!`.
> - **User Database (diesel)**
>   - Log username availability errors with `log::error!`.
> - **Cargo changes**
>   - Wire `log.workspace = true` and `env_logger.workspace = true` in affected crates' `Cargo.toml`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cd6c34a7b71d1be84c5bfa3195eaacbc260fa553. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->