### PR TITLE
⭐ rate-limit: add configurable rate limiting for auth and API routes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -190,6 +190,7 @@ dependencies = [
  "tower",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -208,6 +209,7 @@ dependencies = [
  "sync_wrapper",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -396,6 +398,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
 
 [[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
 name = "crypto-common"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -459,6 +467,20 @@ dependencies = [
  "darling_core",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "dashmap"
+version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5041cc499144891f3790297212f32a74fb938e5136a14943f338ef9e0ae276cf"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
 ]
 
 [[package]]
@@ -741,11 +763,13 @@ dependencies = [
  "fckn-gay-user-database",
  "fckn-gay-validation",
  "getrandom 0.3.4",
+ "governor",
  "log",
  "serde",
  "tokio",
  "toml",
  "tower-http",
+ "tower_governor",
  "uuid",
 ]
 
@@ -828,12 +852,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
 name = "form_urlencoded"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "forwarded-header-value"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8835f84f38484cc86f110a805655697908257fb9a7af005234060891557198e9"
+dependencies = [
+ "nonempty",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -876,6 +916,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
 
 [[package]]
+name = "futures-timer"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
+
+[[package]]
 name = "futures-util"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -883,6 +929,7 @@ checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
  "futures-core",
  "futures-io",
+ "futures-sink",
  "futures-task",
  "memchr",
  "pin-project-lite",
@@ -920,9 +967,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi",
  "wasip2",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "governor"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e23d5986fd4364c2fb7498523540618b4b8d92eec6c36a02e565f66748e2f79"
+dependencies = [
+ "cfg-if",
+ "dashmap",
+ "futures-sink",
+ "futures-timer",
+ "futures-util",
+ "getrandom 0.3.4",
+ "hashbrown 0.16.1",
+ "nonzero_ext",
+ "parking_lot",
+ "portable-atomic",
+ "quanta",
+ "rand",
+ "smallvec",
+ "spinning_top",
+ "web-time",
 ]
 
 [[package]]
@@ -959,6 +1031,11 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash",
+]
 
 [[package]]
 name = "heck"
@@ -1398,6 +1475,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
 
 [[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1452,6 +1538,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "nonempty"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9e591e719385e6ebaeb5ce5d3887f7d5676fceca6411d1925ccc95745f3d6f7"
+
+[[package]]
+name = "nonzero_ext"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38bf9645c8b145698bb0b18a4637dcacbc421ea49bef2317e4fd8065a387cf21"
+
+[[package]]
 name = "num-conv"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1498,6 +1596,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-link",
+]
+
+[[package]]
 name = "password-auth"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1525,6 +1646,26 @@ name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "pin-project"
+version = "1.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677f1add503faace112b9f1373e43e9e054bfdd22ff1a63c1bc485eaec6a6a8a"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "pin-project-lite"
@@ -1632,6 +1773,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "quanta"
+version = "0.12.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3ab5a9d756f0d97bdc89019bd2e4ea098cf9cde50ee7564dde6b81ccc8f06c7"
+dependencies = [
+ "crossbeam-utils",
+ "libc",
+ "once_cell",
+ "raw-cpuid",
+ "wasi",
+ "web-sys",
+ "winapi",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1688,6 +1844,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
  "getrandom 0.3.4",
+]
+
+[[package]]
+name = "raw-cpuid"
+version = "11.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "498cd0dc59d73224351ee52a95fee0f1a617a2eae0e7d9d720cc622c73a54186"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags",
 ]
 
 [[package]]
@@ -1839,6 +2013,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
 name = "security-framework"
 version = "3.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1962,6 +2142,15 @@ checksum = "17129e116933cf371d018bb80ae557e889637989d8638274fb25622827b03881"
 dependencies = [
  "libc",
  "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "spinning_top"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d96d2d1d716fb500937168cc09353ffdc7a012be8475ac7308e1bdf0e3923300"
+dependencies = [
+ "lock_api",
 ]
 
 [[package]]
@@ -2237,6 +2426,7 @@ dependencies = [
  "tokio",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -2278,13 +2468,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
+name = "tower_governor"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44de9b94d849d3c46e06a883d72d408c2de6403367b39df2b1c9d9e7b6736fe6"
+dependencies = [
+ "axum",
+ "forwarded-header-value",
+ "governor",
+ "http",
+ "pin-project",
+ "thiserror 2.0.17",
+ "tower",
+ "tracing",
+]
+
+[[package]]
 name = "tracing"
 version = "0.1.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d15d90a0b5c19378952d479dc858407149d7bb45a14de0142f6c534b16fc647"
 dependencies = [
+ "log",
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2477,6 +2696,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "webpki-root-certs"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2486,6 +2715,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
 name = "winapi-util"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2493,6 +2738,12 @@ checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ csv = { version = "1.3" }
 diesel = { version = "2.3.2", features = ["chrono", "returning_clauses_for_sqlite_3_35", "sqlite", "uuid"] }
 env_logger = "0.11"
 getrandom = "0.3"
+governor = "0.10.2"
 hickory-server = "0.25.2"
 lettre = { version = "0.11", default-features = false }
 log = "0.4"
@@ -37,6 +38,7 @@ thiserror = "2.0"
 tokio = { version = "1", default-features = false }
 toml = { version = "0.8" }
 tower-http = { version = "0.6", default-features = false }
+tower_governor = { version = "0.8.0", default-features = false, features = ["axum"] }
 uuid = { version = "1.18.1", features = ["serde", "v4"] }
 
 [workspace.lints.clippy]

--- a/deny.toml
+++ b/deny.toml
@@ -18,6 +18,7 @@ allow = [
   "MIT",
   "OpenSSL",
   "Unicode-3.0",
+  "Zlib",
 ]
 confidence-threshold = 0.8
 

--- a/example_config.toml
+++ b/example_config.toml
@@ -79,3 +79,16 @@ username = "your_username@example.com"
 password = "[password]"
 # password = { env = "SMTP_PASSWORD" }
 # password = { file = "secrets/smtp_password.txt" }
+
+# Rate limiting to prevent abuse and brute-force attacks
+# Rate limit info is exposed via X-RateLimit-* headers so clients can auto-backoff
+[rate_limit]
+# Auth routes (login, signup, etc) - rate limited by IP address
+# Stricter limits help prevent brute-force password attacks
+auth_burst_size = 10  # max requests before rate limiting kicks in
+auth_per_seconds = 60 # seconds to replenish one request slot
+
+# API routes - rate limited per authenticated user
+# More generous limits since these are legitimate users
+api_burst_size = 30  # max requests before rate limiting kicks in
+api_per_seconds = 60 # seconds to replenish one request slot

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -20,9 +20,11 @@ axum = { workspace = true, features = ["form", "http1", "http2", "json", "tokio"
 axum-extra = { workspace = true, features = ["cookie"] }
 env_logger.workspace = true
 getrandom.workspace = true
+governor.workspace = true
 log.workspace = true
 serde.workspace = true
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
 toml.workspace = true
 tower-http = { workspace = true, features = ["catch-panic", "fs"] }
+tower_governor.workspace = true
 uuid.workspace = true

--- a/server/src/interfaces.rs
+++ b/server/src/interfaces.rs
@@ -7,6 +7,50 @@ use fckn_gay_email::{Email, Interface as EmailInterface};
 use fckn_gay_user_database::{Database as UserDatabase, Interface as UserDatabaseIntferface};
 use serde::{Deserialize, Deserializer};
 
+/// Rate limiting configuration for both auth (IP-based) and API (user-based) routes.
+/// All values are configurable through the server config file.
+#[derive(Clone, Debug, Deserialize)]
+pub struct RateLimitConfig {
+    /// Max burst of requests for auth routes (login, signup, etc) before limiting kicks in
+    #[serde(default = "RateLimitConfig::default_auth_burst_size")]
+    pub auth_burst_size: u32,
+    /// How many seconds it takes to replenish one request slot for auth routes
+    #[serde(default = "RateLimitConfig::default_auth_per_seconds")]
+    pub auth_per_seconds: u64,
+    /// Max burst of requests for API routes before limiting kicks in
+    #[serde(default = "RateLimitConfig::default_api_burst_size")]
+    pub api_burst_size: u32,
+    /// How many seconds it takes to replenish one request slot for API routes
+    #[serde(default = "RateLimitConfig::default_api_per_seconds")]
+    pub api_per_seconds: u64,
+}
+
+impl Default for RateLimitConfig {
+    fn default() -> Self {
+        Self {
+            auth_burst_size: Self::default_auth_burst_size(),
+            auth_per_seconds: Self::default_auth_per_seconds(),
+            api_burst_size: Self::default_api_burst_size(),
+            api_per_seconds: Self::default_api_per_seconds(),
+        }
+    }
+}
+
+impl RateLimitConfig {
+    fn default_auth_burst_size() -> u32 {
+        10
+    }
+    fn default_auth_per_seconds() -> u64 {
+        60
+    }
+    fn default_api_burst_size() -> u32 {
+        30
+    }
+    fn default_api_per_seconds() -> u64 {
+        60
+    }
+}
+
 #[derive(Clone)]
 pub struct PublicSuffix(Arc<String>);
 impl PublicSuffix {
@@ -44,6 +88,9 @@ pub struct Config {
     pub dns: <Dns as DnsInterface>::Config,
     pub user_database: <UserDatabase as UserDatabaseIntferface>::Config,
     pub email: <Email as EmailInterface>::Config,
+    /// Rate limiting settings - if not specified, uses sensible defaults
+    #[serde(default)]
+    pub rate_limit: RateLimitConfig,
 }
 
 impl Config {
@@ -66,6 +113,8 @@ pub struct Interfaces {
     /// a cache for login sessions, gets cleared on server restart
     pub auth_cache: Arc<crate::auth_cache::AuthenticationCache>,
     pub hostname: PublicSuffix,
+    /// Rate limiting configuration
+    pub rate_limit: RateLimitConfig,
 }
 
 impl FromRef<Interfaces> for Arc<Dns> {
@@ -107,12 +156,21 @@ impl Interfaces {
         let email = Email::new(config.email).context("Failed to create Email interface")?;
         let email = Arc::new(email);
 
+        log::info!(
+            "Rate limiting configured: auth={}/{} burst/sec, api={}/{} burst/sec",
+            config.rate_limit.auth_burst_size,
+            config.rate_limit.auth_per_seconds,
+            config.rate_limit.api_burst_size,
+            config.rate_limit.api_per_seconds
+        );
+
         Ok(Interfaces {
             dns,
             user_database,
             email,
             auth_cache: Arc::new(crate::auth_cache::AuthenticationCache::new()),
             hostname: config.public_suffix,
+            rate_limit: config.rate_limit,
         })
     }
 }

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -3,9 +3,10 @@ mod auth;
 mod auth_cache;
 mod error;
 mod interfaces;
+mod rate_limit;
 mod user_routes;
 
-use std::any::Any;
+use std::{any::Any, net::SocketAddr};
 
 use anyhow::{Context, Result};
 use axum::{body::Body, response::Response};
@@ -50,6 +51,10 @@ async fn main() -> Result<()> {
     log::info!("starting server on http://{}", config.address);
     let interfaces = Interfaces::new(config)?;
 
+    // Build rate limiting layers from config
+    let auth_rate_limiter = rate_limit::auth_rate_limit_layer(&interfaces.rate_limit);
+    let api_rate_limiter = rate_limit::api_rate_limit_layer(&interfaces.rate_limit);
+
     // make a web server with axum
     // that uses the interfaces to glue all the functionality together
     // need one extra inteface for the auth cache
@@ -62,10 +67,16 @@ async fn main() -> Result<()> {
     let auth_router = auth::router(interfaces.clone());
 
     let app = auth_router
+        // Rate limit auth routes by IP (prevents brute force attacks)
+        .layer(auth_rate_limiter)
         // html pages that require authentication
         .merge(axum::Router::new().nest("/user", user_routes))
-        // api routes, most will need a valid session or api key
-        .merge(axum::Router::new().nest("/api", api_router))
+        // api routes with per-user rate limiting
+        .merge(
+            axum::Router::new()
+                .nest("/api", api_router)
+                .layer(api_rate_limiter),
+        )
         // WASM files with correct MIME type
         .merge(axum::Router::new().route(
             "/fckn_gay_validation_bg.wasm",
@@ -92,9 +103,13 @@ async fn main() -> Result<()> {
         .layer(CatchPanicLayer::custom(silly_panic_handler))
         .with_state(interfaces);
 
-    axum::serve(listener, app)
-        .await
-        .context("Failed to start server")?;
+    // Use into_make_service_with_connect_info so SmartIpKeyExtractor can access peer IP
+    axum::serve(
+        listener,
+        app.into_make_service_with_connect_info::<SocketAddr>(),
+    )
+    .await
+    .context("Failed to start server")?;
 
     Ok(())
 }

--- a/server/src/rate_limit.rs
+++ b/server/src/rate_limit.rs
@@ -1,0 +1,67 @@
+//! Rate limiting middleware for auth and API routes.
+//!
+//! Uses tower_governor under the hood with two strategies:
+//! - IP-based rate limiting for auth routes (login, signup, etc) via SmartIpKeyExtractor
+//! - User-based rate limiting for API routes via custom UserKeyExtractor
+//!
+//! Rate limit info is exposed via X-RateLimit-* headers so clients can auto-backoff.
+
+use axum::{body::Body, http::Request};
+use tower_governor::{
+    GovernorLayer,
+    errors::GovernorError,
+    governor::GovernorConfigBuilder,
+    key_extractor::{KeyExtractor, SmartIpKeyExtractor},
+};
+
+use crate::{auth_cache::AuthenticatedFor, interfaces::RateLimitConfig};
+
+/// Key extractor that uses the authenticated user's ID for rate limiting.
+/// This should only be used on routes that have already passed through auth middleware,
+/// so the AuthenticatedFor extension should always be present.
+#[derive(Debug, Clone)]
+pub struct UserKeyExtractor;
+
+impl KeyExtractor for UserKeyExtractor {
+    type Key = String;
+
+    fn extract<T>(&self, req: &Request<T>) -> Result<Self::Key, GovernorError> {
+        req.extensions()
+            .get::<AuthenticatedFor>()
+            .map(|auth: &AuthenticatedFor| auth.user_id().to_string())
+            .ok_or_else(|| GovernorError::UnableToExtractKey)
+    }
+}
+
+/// Creates a GovernorLayer for auth routes (login, signup, etc).
+/// Uses SmartIpKeyExtractor which checks x-forwarded-for, x-real-ip, forwarded headers
+/// before falling back to peer IP - works nicely behind reverse proxies.
+pub fn auth_rate_limit_layer(
+    config: &RateLimitConfig,
+) -> GovernorLayer<SmartIpKeyExtractor, governor::middleware::StateInformationMiddleware, Body> {
+    let governor_conf = GovernorConfigBuilder::default()
+        .per_second(config.auth_per_seconds)
+        .burst_size(config.auth_burst_size)
+        .key_extractor(SmartIpKeyExtractor)
+        .use_headers() // exposes x-ratelimit-* headers to clients
+        .finish()
+        .expect("auth rate limit config should be valid");
+
+    GovernorLayer::new(governor_conf)
+}
+
+/// Creates a GovernorLayer for API routes.
+/// Uses UserKeyExtractor to rate limit per authenticated user.
+pub fn api_rate_limit_layer(
+    config: &RateLimitConfig,
+) -> GovernorLayer<UserKeyExtractor, governor::middleware::StateInformationMiddleware, Body> {
+    let governor_conf = GovernorConfigBuilder::default()
+        .per_second(config.api_per_seconds)
+        .burst_size(config.api_burst_size)
+        .key_extractor(UserKeyExtractor)
+        .use_headers() // exposes x-ratelimit-* headers to clients
+        .finish()
+        .expect("api rate limit config should be valid");
+
+    GovernorLayer::new(governor_conf)
+}


### PR DESCRIPTION
## Summary

Implements configurable rate limiting for the server, addressing issue #3.

### Features

- **IP-based rate limiting** for auth routes (login, signup, confirm-signup, logout) using `SmartIpKeyExtractor` - handles reverse proxies by checking x-forwarded-for, x-real-ip, forwarded headers
- **Per-user rate limiting** for API routes using a custom `UserKeyExtractor` that extracts the user ID from the auth session
- **Fully configurable** via `[rate_limit]` section in config.toml:
  - `auth_burst_size` / `auth_per_seconds` - limits for auth routes
  - `api_burst_size` / `api_per_seconds` - limits for API routes
- **X-RateLimit headers** exposed to clients so they can implement auto-backoff:
  - `x-ratelimit-limit`
  - `x-ratelimit-remaining`
  - `x-ratelimit-after`
  - `retry-after`

### Config Example

```toml
[rate_limit]
auth_burst_size = 10
auth_per_seconds = 60
api_burst_size = 30
api_per_seconds = 60
```

### Technical Details

- Uses `tower_governor` (v0.8.0) backed by the `governor` crate
- Rate limit layers are applied at the router level in main.rs
- Sensible defaults if `[rate_limit]` section is omitted
- Added Zlib license to deny.toml for `foldhash` dependency

Closes #3

