### PR TITLE
⭐Add --dummy option and warn if enabling real DNS with dummy database

### DIFF
--- a/dns/src/lib.rs
+++ b/dns/src/lib.rs
@@ -73,6 +73,17 @@ pub struct Config {
 }
 
 impl Config {
+    /// Constructs a minimal all-dummy config. Requires the `dummy` feature.
+    #[cfg(feature = "dummy")]
+    pub fn dummy() -> Self {
+        Config {
+            provider: Some(Providers::Dummy),
+            dummy: Some(fckn_gay_dns_dummy::Config { entries: vec![] }),
+            porkbun: None,
+            hickory: None,
+        }
+    }
+
     /// Warns about provider configs that are present but won't be validated
     /// because the feature isn't compiled in.
     fn warn_uncompiled_providers(&self) {
@@ -175,6 +186,24 @@ pub struct Dns {
 }
 
 impl Dns {
+    /// Returns `true` if the active provider is the in-memory dummy.
+    pub fn is_dummy(&self) -> bool {
+        #[cfg(feature = "dummy")]
+        if matches!(self.active, ActiveDns::Dummy(_)) {
+            return true;
+        }
+        false
+    }
+
+    /// Returns `true` if the active provider is Hickory (local DNS server).
+    pub fn is_hickory(&self) -> bool {
+        #[cfg(feature = "hickory")]
+        if matches!(self.active, ActiveDns::Hickory(_)) {
+            return true;
+        }
+        false
+    }
+
     #[cfg(feature = "porkbun")]
     pub fn porkbun(&self) -> Result<&Porkbun, Error> {
         self.active

--- a/email/src/lib.rs
+++ b/email/src/lib.rs
@@ -60,6 +60,16 @@ pub struct Config {
 }
 
 impl Config {
+    /// Constructs a minimal all-dummy config (emails printed to stdout). Requires the `dummy` feature.
+    #[cfg(feature = "dummy")]
+    pub fn dummy() -> Self {
+        Config {
+            provider: Some(Providers::Dummy),
+            dummy: Some(fckn_gay_email_dummy::Config::default()),
+            lettre: None,
+        }
+    }
+
     /// Warns about provider configs that are present but won't be validated
     /// because the feature isn't compiled in.
     fn warn_uncompiled_providers(&self) {

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -9,10 +9,10 @@ workspace = true
 
 [dependencies]
 # interfaces
-fckn-gay-dns.workspace = true
-fckn-gay-email.workspace = true
+fckn-gay-dns = { workspace = true, features = ["dummy"] }
+fckn-gay-email = { workspace = true, features = ["dummy"] }
 fckn-gay-secret.workspace = true
-fckn-gay-user-database.workspace = true
+fckn-gay-user-database = { workspace = true, features = ["dummy"] }
 fckn-gay-validation.workspace = true
 
 # other dependencies

--- a/server/src/interfaces.rs
+++ b/server/src/interfaces.rs
@@ -125,6 +125,20 @@ impl Config {
         toml::from_str(&config_str)
             .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))
     }
+
+    /// Builds a fully-dummy config for local dev / testing.
+    /// Binds to 127.0.0.1:3000, uses in-memory providers for everything.
+    pub fn dummy() -> Self {
+        Config {
+            address: "127.0.0.1:3000".to_string(),
+            public_suffix: PublicSuffix::new("localhost".to_string()),
+            dns: fckn_gay_dns::Config::dummy(),
+            user_database: fckn_gay_user_database::Config::dummy(),
+            email: fckn_gay_email::Config::dummy(),
+            rate_limit: RateLimitConfig::default(),
+            turnstile: None,
+        }
+    }
 }
 
 #[derive(Clone)]
@@ -204,6 +218,16 @@ impl Interfaces {
         let user_database = Arc::new(user_database);
         let email = Email::new(config.email).context("Failed to create Email interface")?;
         let email = Arc::new(email);
+
+        // dummy DB + real DNS = data loss city 💀 DNS records will accumulate forever since the
+        // in-memory DB forgets everything on restart but Porkbun/etc keeps the actual records.
+        if user_database.is_dummy() && !dns.is_dummy() && !dns.is_hickory() {
+            log::warn!(
+                "⚠️  DANGEROUS CONFIG: dummy user database + real DNS provider! \
+                 DNS records created will be permanently lost on restart since the dummy DB \
+                 doesn't persist. Please use the dummy or hickory DNS provider for testing."
+            );
+        }
 
         log::info!(
             "Rate limiting configured: auth={}/{} burst/sec, api={}/{} burst/sec",

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -46,6 +46,9 @@ struct Args {
     /// Path to config file
     #[arg(long, default_value = "config.toml")]
     config: PathBuf,
+    /// Use in-memory dummy providers for everything (ignores --config).
+    #[arg(long)]
+    dummy: bool,
 }
 
 #[tokio::main]
@@ -53,7 +56,12 @@ async fn main() -> Result<()> {
     env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info")).init();
     let args = Args::parse();
 
-    let config = Config::load_from_file(&args.config)?;
+    let config = if args.dummy {
+        log::info!("--dummy mode: using in-memory providers for everything, ignoring config file");
+        Config::dummy()
+    } else {
+        Config::load_from_file(&args.config)?
+    };
     let listener = tokio::net::TcpListener::bind(&config.address)
         .await
         .context("Failed to bind to address")?;

--- a/user-database/implementors/dummy/src/lib.rs
+++ b/user-database/implementors/dummy/src/lib.rs
@@ -13,7 +13,7 @@ pub struct Database {
     records: tokio::sync::Mutex<BTreeMap<Uuid, Vec<DatabaseDnsRecord>>>,
 }
 
-#[derive(Debug, serde::Deserialize)]
+#[derive(Debug, Default, serde::Deserialize)]
 pub struct Config(BTreeMap<String, String>);
 
 #[derive(Debug)]

--- a/user-database/src/lib.rs
+++ b/user-database/src/lib.rs
@@ -41,6 +41,17 @@ pub enum Database {
     Diesel(DieselDatabase),
 }
 
+impl Database {
+    /// Returns `true` if the active provider is the in-memory dummy (data lost on restart!).
+    pub fn is_dummy(&self) -> bool {
+        #[cfg(feature = "dummy")]
+        if matches!(self, Database::Dummy(_)) {
+            return true;
+        }
+        false
+    }
+}
+
 impl<'de> Deserialize<'de> for Database {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
@@ -149,6 +160,17 @@ pub struct Config {
 }
 
 impl Config {
+    /// Constructs a minimal all-dummy config with no pre-seeded users. Requires the `dummy` feature.
+    #[cfg(feature = "dummy")]
+    pub fn dummy() -> Self {
+        Config {
+            provider: Some(Providers::Dummy),
+            dummy: Some(fckn_gay_user_database_dummy::Config::default()),
+            csv: None,
+            diesel: None,
+        }
+    }
+
     /// Warns about provider configs that are present but won't be validated
     /// because the feature isn't compiled in.
     fn warn_uncompiled_providers(&self) {


### PR DESCRIPTION
Adds a `--dummy` option to the server to allow for testing w/o a config file and will warn the user when instantiating a config with a dummy database but non-local DNS provider