### PR TITLE
CLI tools for user database management

### DIFF
--- a/server/src/cli_commands/edit_user.rs
+++ b/server/src/cli_commands/edit_user.rs
@@ -1,0 +1,384 @@
+use anyhow::Result;
+use fckn_gay_dns::{Dns, Interface as DnsInterface};
+use fckn_gay_user_database::{
+    Database as UserDatabase, Interface as UserDatabaseInterface, PasswordHash, UserState,
+};
+
+use super::util::generate_random_password;
+use crate::interfaces::PublicSuffix;
+
+pub struct EditUserOpts {
+    pub email: Option<String>,
+    pub state: Option<UserState>,
+    pub reset_password: bool,
+    pub rename: Option<String>,
+    pub dry_run: bool,
+}
+
+pub async fn run(
+    dns: &Dns,
+    user_db: &UserDatabase,
+    suffix: &PublicSuffix,
+    username: &str,
+    opts: EditUserOpts,
+) -> Result<()> {
+    let entry = user_db
+        .get_user_by_username_or_email(username)
+        .await
+        .map_err(|e| anyhow::anyhow!("failed to look up user '{username}': {e}"))?
+        .ok_or_else(|| anyhow::anyhow!("user '{username}' not found 💀"))?;
+
+    let user_id = entry.id;
+
+    let has_changes = opts.email.is_some()
+        || opts.state.is_some()
+        || opts.reset_password
+        || opts.rename.is_some();
+
+    if !has_changes {
+        eprintln!("📋 user info for '{username}':");
+        eprintln!("  id:         {}", entry.id);
+        eprintln!("  username:   {}", entry.username);
+        eprintln!("  email:      {}", entry.email);
+        eprintln!("  state:      {}", entry.state);
+        eprintln!("  created_at: {}", entry.created_at);
+        eprintln!(
+            "  last_login: {}",
+            entry
+                .last_login
+                .map_or("never".to_string(), |t| t.to_string())
+        );
+        return Ok(());
+    }
+
+    if opts.dry_run {
+        eprintln!("🧪 DRY RUN -- no changes will be made");
+    }
+
+    // -- email --
+    if let Some(ref new_email) = opts.email {
+        if opts.dry_run {
+            eprintln!("📧 would update email: {} -> {new_email}", entry.email);
+        } else {
+            user_db
+                .update_user_email(user_id, new_email)
+                .await
+                .map_err(|e| anyhow::anyhow!("failed to update email: {e}"))?;
+            eprintln!("📧 updated email: {} -> {new_email}", entry.email);
+        }
+    }
+
+    // -- state --
+    if let Some(new_state) = opts.state {
+        if opts.dry_run {
+            eprintln!("🔄 would update state: {} -> {new_state}", entry.state);
+        } else {
+            user_db
+                .update_user_state(user_id, new_state)
+                .await
+                .map_err(|e| anyhow::anyhow!("failed to update state: {e}"))?;
+            eprintln!("🔄 updated state: {} -> {new_state}", entry.state);
+        }
+    }
+
+    // -- password reset --
+    if opts.reset_password {
+        if opts.dry_run {
+            eprintln!("🔑 would reset password (new password not generated in dry run)");
+        } else {
+            let new_pw = generate_random_password();
+            user_db
+                .update_user_password(user_id, PasswordHash::new(&new_pw))
+                .await
+                .map_err(|e| anyhow::anyhow!("failed to reset password: {e}"))?;
+            eprintln!("🔑 password reset! new password: {new_pw}");
+        }
+    }
+
+    // -- rename (the spicy one 🌶️) --
+    if let Some(ref new_username) = opts.rename {
+        rename_user(
+            dns,
+            user_db,
+            suffix,
+            user_id,
+            &entry.username,
+            new_username,
+            opts.dry_run,
+        )
+        .await?;
+    }
+
+    if opts.dry_run {
+        eprintln!("\n(dry run -- nothing was actually changed)");
+    } else {
+        eprintln!("\n✨ done!");
+    }
+
+    Ok(())
+}
+
+/// Rename a user: update username in DB + migrate all their DNS records upstream.
+///
+/// Since Porkbun doesn't support updating records in-place, we do delete + add per record.
+/// Failed upstream adds go to a retry queue with exponential backoff (1s, 2s, 4s).
+async fn rename_user(
+    dns: &Dns,
+    user_db: &UserDatabase,
+    suffix: &PublicSuffix,
+    user_id: fckn_gay_user_database::Uuid,
+    old_username: &str,
+    new_username: &str,
+    dry_run: bool,
+) -> Result<()> {
+    eprintln!("\n🏷️  renaming '{old_username}' -> '{new_username}'...");
+
+    let validation = fckn_gay_validation::validate_username(new_username);
+    if !validation.is_valid() {
+        anyhow::bail!(
+            "username '{new_username}' is invalid: {}",
+            validation.errors().join(", ")
+        );
+    }
+
+    if !user_db.is_available(new_username).await {
+        anyhow::bail!("username '{new_username}' is already taken, can't rename");
+    }
+
+    let db_records = user_db
+        .get_user_dns_records(user_id)
+        .await
+        .map_err(|e| anyhow::anyhow!("failed to fetch DNS records: {e}"))?;
+
+    if dry_run {
+        eprintln!("  would update username in DB: {old_username} -> {new_username}");
+        for rec in &db_records {
+            let new_name = rename_record_name(&rec.record.name, old_username, new_username, suffix);
+            eprintln!(
+                "  would rename record: {} -> {new_name} ({} -> {})",
+                rec.record.name, rec.record.record_type, rec.record.content,
+            );
+        }
+        return Ok(());
+    }
+
+    // Step 1: update username in DB first
+    user_db
+        .update_username(user_id, new_username)
+        .await
+        .map_err(|e| anyhow::anyhow!("failed to update username in DB: {e}"))?;
+    eprintln!("  ✅ updated username in DB");
+
+    // Step 2: migrate DNS records
+    if db_records.is_empty() {
+        eprintln!("  no DNS records to rename");
+        return Ok(());
+    }
+
+    struct PendingRename {
+        old_provider_key: String,
+        old_record_id: fckn_gay_user_database::DnsRecordId,
+        new_record: fckn_gay_dns::Record,
+    }
+
+    let mut pending: Vec<PendingRename> = db_records
+        .iter()
+        .map(|rec| {
+            let new_name = rename_record_name(&rec.record.name, old_username, new_username, suffix);
+            let mut new_record = rec.record.clone();
+            new_record.name = new_name;
+            PendingRename {
+                old_provider_key: rec.provider_key.clone(),
+                old_record_id: rec.id,
+                new_record,
+            }
+        })
+        .collect();
+
+    let mut succeeded = 0u32;
+    let mut dangling_old = 0u32;
+    let backoff_durations = [
+        std::time::Duration::from_secs(1),
+        std::time::Duration::from_secs(2),
+        std::time::Duration::from_secs(4),
+        std::time::Duration::from_secs(16),
+    ];
+    let max_attempts = 1 + backoff_durations.len(); // first try + retries
+
+    for attempt in 0..max_attempts {
+        if pending.is_empty() {
+            break;
+        }
+
+        if attempt > 0 {
+            let wait = backoff_durations[attempt - 1];
+            eprintln!(
+                "  ⏳ retrying {} failed record(s) after {}s...",
+                pending.len(),
+                wait.as_secs()
+            );
+            tokio::time::sleep(wait).await;
+        }
+
+        let mut still_failing = Vec::new();
+
+        for rename in pending.drain(..) {
+            // 1. add new record upstream
+            let new_key = match dns.add_record(rename.new_record.clone()).await {
+                Ok(key) => key,
+                Err(e) => {
+                    eprintln!(
+                        "  ⚠️  failed to add '{}' upstream: {e}",
+                        rename.new_record.name
+                    );
+                    still_failing.push(rename);
+                    continue;
+                }
+            };
+
+            // 2. delete old DB record
+            if let Err(e) = user_db
+                .delete_dns_record(user_id, rename.old_record_id)
+                .await
+            {
+                eprintln!(
+                    "  ⚠️  failed to delete old DB record for '{}': {e}",
+                    rename.new_record.name
+                );
+            }
+
+            // 3. add new DB record with new provider key
+            if let Err(e) = user_db
+                .add_dns_record(user_id, rename.new_record.clone(), new_key.to_string())
+                .await
+            {
+                eprintln!(
+                    "  ⚠️  failed to add new DB record for '{}': {e}",
+                    rename.new_record.name
+                );
+            }
+
+            // 4. delete old upstream record (non-fatal)
+            let old_key: fckn_gay_dns::Key = match rename.old_provider_key.parse() {
+                Ok(k) => k,
+                Err(e) => {
+                    eprintln!(
+                        "  ⚠️  can't parse old provider key '{}': {e} -- old record may linger",
+                        rename.old_provider_key
+                    );
+                    dangling_old += 1;
+                    succeeded += 1;
+                    continue;
+                }
+            };
+
+            if let Err(e) = dns.delete_record(old_key).await {
+                eprintln!(
+                    "  ⚠️  failed to delete old upstream record '{}': {e} -- may linger",
+                    rename.old_provider_key
+                );
+                dangling_old += 1;
+            }
+
+            succeeded += 1;
+            eprintln!("  ✅ renamed record -> {}", rename.new_record.name);
+        }
+
+        pending = still_failing;
+    }
+
+    let failed = pending.len() as u32;
+    eprintln!("\n  === rename summary ===");
+    eprintln!("  records renamed:   {succeeded}");
+    if dangling_old > 0 {
+        eprintln!("  old records left:  {dangling_old} (may need manual cleanup)");
+    }
+    if failed > 0 {
+        eprintln!("  records failed:    {failed}");
+        for rename in &pending {
+            eprintln!("    ❌ {}", rename.new_record.name);
+        }
+    }
+
+    Ok(())
+}
+
+/// Replace the old username portion in a DNS record name with the new username.
+///
+/// e.g. `sub.alice.is.fckn.gay` with old=`alice`, new=`bob` -> `sub.bob.is.fckn.gay`
+fn rename_record_name(
+    record_name: &str,
+    old_username: &str,
+    new_username: &str,
+    suffix: &PublicSuffix,
+) -> String {
+    let suffix_str = suffix.as_str();
+
+    // The record name should be <prefix>.<old_username><suffix>
+    // where <prefix> might be empty (just <old_username><suffix>)
+    let old_label = format!("{old_username}{suffix_str}");
+    if let Some(prefix) = record_name.strip_suffix(&old_label) {
+        let new_label = format!("{new_username}{suffix_str}");
+        format!("{prefix}{new_label}")
+    } else {
+        // fallback: only replace if old_username appears as a full dot-delimited label
+        let dot_old = format!(".{old_username}.");
+        if let Some(pos) = record_name.find(&dot_old) {
+            format!(
+                "{}.{new_username}.{}",
+                &record_name[..pos],
+                &record_name[pos + dot_old.len()..]
+            )
+        } else if let Some(rest) = record_name.strip_prefix(&format!("{old_username}.")) {
+            format!("{new_username}.{rest}")
+        } else {
+            eprintln!(
+                "  ⚠️  couldn't find '{old_username}' as a label in '{record_name}' -- leaving as-is"
+            );
+            record_name.to_string()
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn suffix(s: &str) -> PublicSuffix {
+        PublicSuffix::new(s.to_string())
+    }
+
+    #[test]
+    fn rename_simple() {
+        assert_eq!(
+            rename_record_name("alice.is.fckn.gay", "alice", "bob", &suffix(".is.fckn.gay")),
+            "bob.is.fckn.gay"
+        );
+    }
+
+    #[test]
+    fn rename_nested() {
+        assert_eq!(
+            rename_record_name(
+                "sub.alice.is.fckn.gay",
+                "alice",
+                "bob",
+                &suffix(".is.fckn.gay")
+            ),
+            "sub.bob.is.fckn.gay"
+        );
+    }
+
+    #[test]
+    fn rename_wildcard_nested() {
+        assert_eq!(
+            rename_record_name(
+                "*.alice.is.fckn.gay",
+                "alice",
+                "bob",
+                &suffix(".is.fckn.gay")
+            ),
+            "*.bob.is.fckn.gay"
+        );
+    }
+}

--- a/server/src/cli_commands/migrate.rs
+++ b/server/src/cli_commands/migrate.rs
@@ -1,0 +1,465 @@
+use std::{
+    collections::{BTreeMap, HashSet},
+    io::{self, BufRead, Write},
+};
+
+use anyhow::{Context, Result};
+use fckn_gay_dns::{Dns, Interface as DnsInterface};
+use fckn_gay_user_database::{Database as UserDatabase, Interface as UserDatabaseInterface};
+
+use super::util::generate_random_password;
+use crate::interfaces::PublicSuffix;
+
+/// Given a record name like `admin.is.fckn.gay` and a suffix like `.is.fckn.gay`,
+/// extracts the top-level username label (`admin`).
+/// For nested subdomains like `sub.alice.is.fckn.gay`, the username is `alice`
+/// (the label immediately before the suffix).
+///
+/// Returns `None` for wildcards (`*`), empty labels, and non-matching suffixes.
+fn extract_username(record_name: &str, suffix: &str) -> Option<String> {
+    let name = record_name.to_ascii_lowercase();
+    let suffix_lower = suffix.to_ascii_lowercase();
+    let without_suffix = name.strip_suffix(&suffix_lower)?;
+    let username = without_suffix.rsplit('.').next()?;
+    if username.is_empty() || username == "*" {
+        return None;
+    }
+    Some(username.to_string())
+}
+
+/// Prompt for a line of input. Returns the trimmed input, or `None` if it was blank.
+fn prompt(label: &str) -> Option<String> {
+    eprint!("  {label}");
+    io::stderr().flush().ok();
+    let mut buf = String::new();
+    io::stdin()
+        .lock()
+        .read_line(&mut buf)
+        .expect("failed to read stdin");
+    let trimmed = buf.trim().to_string();
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(trimmed)
+    }
+}
+
+const DEFAULT_EMAIL: &str = "im@fckn.gay";
+
+struct MigrationStats {
+    users_created: u32,
+    users_deleted: u32,
+    records_imported: u32,
+    records_already_synced: u32,
+    records_deleted: u32,
+}
+
+/// Run the DNS -> user_database migration.
+///
+/// 1. Fetches all records from the DNS provider
+/// 2. Filters to records matching the public suffix
+/// 3. Creates missing users (with interactive prompts)
+/// 4. Syncs the records database to match upstream
+/// 5. Reports records present in the DB but missing upstream
+///
+/// If `dry_run` is true, no changes are made -- we just report what *would* happen.
+pub async fn run(
+    dns: &Dns,
+    user_db: &UserDatabase,
+    suffix: &PublicSuffix,
+    dry_run: bool,
+) -> Result<()> {
+    let suffix_str = suffix.as_str();
+    if dry_run {
+        eprintln!("🧪 DRY RUN -- no changes will be made");
+    }
+    eprintln!("🔍 fetching all records from DNS provider...");
+
+    let upstream_records = dns
+        .list_records()
+        .await
+        .context("failed to list records from DNS provider")?;
+
+    eprintln!("   found {} total records upstream", upstream_records.len());
+
+    // Filter to records belonging to our public suffix and group by username
+    let mut by_user: BTreeMap<String, Vec<(String, fckn_gay_dns::Record)>> = BTreeMap::new();
+    let mut skipped = 0u32;
+
+    for (key, record) in &upstream_records {
+        match extract_username(&record.name, suffix_str) {
+            Some(username) => {
+                by_user
+                    .entry(username)
+                    .or_default()
+                    .push((key.to_string(), record.clone()));
+            }
+            None => {
+                skipped += 1;
+            }
+        }
+    }
+
+    eprintln!(
+        "   {n_users} users with {n_records} records match suffix '{suffix_str}' ({skipped} records skipped)",
+        n_users = by_user.len(),
+        n_records = by_user.values().map(|v| v.len()).sum::<usize>(),
+    );
+
+    if by_user.is_empty() {
+        eprintln!("nothing to migrate, we're done here ✨");
+        return Ok(());
+    }
+
+    let mut stats = MigrationStats {
+        users_created: 0,
+        users_deleted: 0,
+        records_imported: 0,
+        records_already_synced: 0,
+        records_deleted: 0,
+    };
+
+    let upstream_usernames: HashSet<&str> = by_user.keys().map(|s| s.as_str()).collect();
+
+    for (username, upstream) in &by_user {
+        eprintln!("\n--- {username} ({} records upstream) ---", upstream.len());
+
+        let user_id = ensure_user_exists(user_db, username, &mut stats, dry_run).await?;
+
+        sync_records_for_user(user_db, user_id, username, upstream, &mut stats, dry_run).await?;
+    }
+
+    // Check for users in the DB that have no records upstream
+    cleanup_orphaned_users(user_db, &upstream_usernames, &mut stats, dry_run).await?;
+
+    if dry_run {
+        eprintln!("\n(dry run -- nothing was actually changed)");
+    }
+
+    let label = if dry_run { "dry run" } else { "migration" };
+    eprintln!("\n========== {label} summary ==========");
+    if dry_run {
+        eprintln!("  users to create:         {}", stats.users_created);
+        eprintln!("  users to delete:         {}", stats.users_deleted);
+        eprintln!("  records to import:       {}", stats.records_imported);
+        eprintln!("  records to delete:       {}", stats.records_deleted);
+    } else {
+        eprintln!("  users created:           {}", stats.users_created);
+        eprintln!("  users deleted:           {}", stats.users_deleted);
+        eprintln!("  records imported:        {}", stats.records_imported);
+        eprintln!("  records deleted:         {}", stats.records_deleted);
+    }
+    eprintln!(
+        "  records already synced:  {}",
+        stats.records_already_synced
+    );
+    eprintln!("========================================");
+
+    Ok(())
+}
+
+/// Make sure a user exists in the database. If they don't, interactively prompt
+/// for password + email and create + activate them.
+/// Returns `Some(uuid)` on success, or `None` in dry-run mode when the user
+/// doesn't exist yet (we can't get an ID without actually creating them).
+async fn ensure_user_exists(
+    user_db: &UserDatabase,
+    username: &str,
+    stats: &mut MigrationStats,
+    dry_run: bool,
+) -> Result<Option<fckn_gay_user_database::Uuid>> {
+    if user_db.is_available(username).await {
+        if dry_run {
+            eprintln!(
+                "  🆕 would create user '{username}' (password: random, email: {DEFAULT_EMAIL} unless overridden)"
+            );
+            stats.users_created += 1;
+            return Ok(None);
+        }
+
+        // User doesn't exist yet -- create them
+        let password = match prompt("Password [blank = random]: ") {
+            Some(pw) => {
+                eprintln!("  (using provided password)");
+                pw
+            }
+            None => {
+                let pw = generate_random_password();
+                eprintln!("  password generated!");
+                pw
+            }
+        };
+
+        let email = prompt(&format!("Email [blank = {DEFAULT_EMAIL}]: "))
+            .unwrap_or_else(|| DEFAULT_EMAIL.to_string());
+
+        let uuid = user_db
+            .add_user(username, &password, &email)
+            .await
+            .map_err(|e| anyhow::anyhow!("failed to create user '{username}': {e}"))?;
+
+        // Skip the email confirmation dance -- this is an admin migration
+        user_db
+            .activate_user(uuid)
+            .await
+            .map_err(|e| anyhow::anyhow!("failed to activate user '{username}': {e}"))?;
+
+        eprintln!("  ✅ created + activated user '{username}'");
+        stats.users_created += 1;
+        Ok(Some(uuid))
+    } else {
+        // User exists -- grab their ID
+        let entry = user_db
+            .get_user_by_username_or_email(username)
+            .await
+            .map_err(|e| anyhow::anyhow!("failed to look up user '{username}': {e}"))?
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "user '{username}' is marked as unavailable but we can't find them 💀"
+                )
+            })?;
+
+        eprintln!("  user '{username}' already exists (id: {})", entry.id);
+        Ok(Some(entry.id))
+    }
+}
+
+/// Compare upstream DNS records with what's in the user database for a given user.
+/// Import anything missing from the DB, report anything in the DB but gone upstream.
+///
+/// `user_id` is `None` when dry-running for a user that doesn't exist yet --
+/// in that case every upstream record counts as "would be imported".
+async fn sync_records_for_user(
+    user_db: &UserDatabase,
+    user_id: Option<fckn_gay_user_database::Uuid>,
+    username: &str,
+    upstream: &[(String, fckn_gay_dns::Record)],
+    stats: &mut MigrationStats,
+    dry_run: bool,
+) -> Result<()> {
+    // If we don't have a user_id (dry-run for a new user), there are no DB
+    // records to compare against -- everything upstream would be imported.
+    let db_records = match user_id {
+        Some(id) => user_db
+            .get_user_dns_records(id)
+            .await
+            .map_err(|e| anyhow::anyhow!("failed to fetch DB records for '{username}': {e}"))?,
+        None => Vec::new(),
+    };
+
+    // Set of provider keys that exist upstream
+    let upstream_keys: HashSet<&str> = upstream.iter().map(|(k, _)| k.as_str()).collect();
+
+    // Set of provider keys already in the DB
+    let db_keys: HashSet<&str> = db_records.iter().map(|r| r.provider_key.as_str()).collect();
+
+    let verb = if dry_run { "would import" } else { "imported" };
+    let icon = if dry_run { "📋" } else { "📥" };
+
+    // Records upstream but not in DB -> import (or report)
+    for (provider_key, record) in upstream {
+        if db_keys.contains(provider_key.as_str()) {
+            stats.records_already_synced += 1;
+            continue;
+        }
+
+        if !dry_run && let Some(id) = user_id {
+            user_db
+                .add_dns_record(id, record.clone(), provider_key.clone())
+                .await
+                .map_err(|e| {
+                    anyhow::anyhow!(
+                        "failed to import record '{}' ({}) for '{username}': {e}",
+                        record.name,
+                        record.record_type,
+                    )
+                })?;
+        }
+
+        eprintln!(
+            "  {icon} {verb}: {} {} -> {}",
+            record.name, record.record_type, record.content
+        );
+        stats.records_imported += 1;
+    }
+
+    // Records in DB but not upstream -> delete locally
+    for db_rec in &db_records {
+        if upstream_keys.contains(db_rec.provider_key.as_str()) {
+            continue;
+        }
+
+        if dry_run {
+            eprintln!(
+                "  🗑️  would delete local record (gone upstream): {} {} -> {}",
+                db_rec.record.name, db_rec.record.record_type, db_rec.record.content,
+            );
+        } else if let Some(id) = user_id {
+            user_db
+                .delete_dns_record(id, db_rec.id)
+                .await
+                .map_err(|e| {
+                    anyhow::anyhow!(
+                        "failed to delete stale record '{}' ({}) for '{username}': {e}",
+                        db_rec.record.name,
+                        db_rec.record.record_type,
+                    )
+                })?;
+            eprintln!(
+                "  🗑️  deleted local record (gone upstream): {} {} -> {}",
+                db_rec.record.name, db_rec.record.record_type, db_rec.record.content,
+            );
+        }
+        stats.records_deleted += 1;
+    }
+
+    Ok(())
+}
+
+/// Find users in the local DB that don't have any records upstream and offer to
+/// delete them (including their local DNS records).
+async fn cleanup_orphaned_users(
+    user_db: &UserDatabase,
+    upstream_usernames: &HashSet<&str>,
+    stats: &mut MigrationStats,
+    dry_run: bool,
+) -> Result<()> {
+    let all_users = user_db
+        .list_all_users()
+        .await
+        .map_err(|e| anyhow::anyhow!("failed to list all users: {e}"))?;
+
+    let orphans: Vec<_> = all_users
+        .iter()
+        .filter(|u| !upstream_usernames.contains(u.username.as_str()))
+        .collect();
+
+    if orphans.is_empty() {
+        return Ok(());
+    }
+
+    eprintln!(
+        "\n🔎 found {} user(s) in DB with no records upstream:",
+        orphans.len()
+    );
+    for user in &orphans {
+        let n_records = user_db
+            .get_user_dns_records(user.id)
+            .await
+            .map(|r| r.len())
+            .unwrap_or(0);
+
+        if dry_run {
+            eprintln!(
+                "  🗑️  would delete user '{}' ({n_records} local records)",
+                user.username
+            );
+            stats.users_deleted += 1;
+            stats.records_deleted += n_records as u32;
+            continue;
+        }
+
+        eprint!(
+            "  Delete user '{}' ({n_records} local records)? [y/N] ",
+            user.username
+        );
+        io::stderr().flush().ok();
+        let mut answer = String::new();
+        io::stdin()
+            .lock()
+            .read_line(&mut answer)
+            .expect("failed to read stdin");
+
+        if answer.trim().eq_ignore_ascii_case("y") {
+            // Delete their DNS records first, then the user
+            let records = user_db.get_user_dns_records(user.id).await.map_err(|e| {
+                anyhow::anyhow!(
+                    "failed to fetch records for orphaned user '{}': {e}",
+                    user.username
+                )
+            })?;
+            for rec in &records {
+                user_db
+                    .delete_dns_record(user.id, rec.id)
+                    .await
+                    .map_err(|e| {
+                        anyhow::anyhow!("failed to delete record for '{}': {e}", user.username)
+                    })?;
+            }
+            user_db
+                .delete_user(&user.username)
+                .await
+                .map_err(|e| anyhow::anyhow!("failed to delete user '{}': {e}", user.username))?;
+            eprintln!(
+                "  🗑️  deleted user '{}' + {n_records} records",
+                user.username
+            );
+            stats.users_deleted += 1;
+            stats.records_deleted += records.len() as u32;
+        } else {
+            eprintln!("  ⏭️  skipped '{}'", user.username);
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn extract_username_basic() {
+        assert_eq!(
+            extract_username("admin.is.fckn.gay", ".is.fckn.gay"),
+            Some("admin".into())
+        );
+    }
+
+    #[test]
+    fn extract_username_nested_subdomain() {
+        assert_eq!(
+            extract_username("sub.alice.is.fckn.gay", ".is.fckn.gay"),
+            Some("alice".into())
+        );
+    }
+
+    #[test]
+    fn extract_username_case_insensitive() {
+        assert_eq!(
+            extract_username("ALICE.Is.Fckn.Gay", ".is.fckn.gay"),
+            Some("alice".into())
+        );
+    }
+
+    #[test]
+    fn extract_username_wrong_suffix() {
+        assert_eq!(extract_username("admin.other.domain", ".is.fckn.gay"), None);
+    }
+
+    #[test]
+    fn extract_username_bare_suffix() {
+        assert_eq!(extract_username(".is.fckn.gay", ".is.fckn.gay"), None);
+    }
+
+    #[test]
+    fn extract_username_wildcard() {
+        assert_eq!(extract_username("*.is.fckn.gay", ".is.fckn.gay"), None);
+    }
+
+    #[test]
+    fn extract_username_nested_wildcard() {
+        // *.alice.is.fckn.gay -> username is alice, not *
+        assert_eq!(
+            extract_username("*.alice.is.fckn.gay", ".is.fckn.gay"),
+            Some("alice".into())
+        );
+    }
+
+    #[test]
+    fn random_password_is_32_chars() {
+        let pw = generate_random_password();
+        assert_eq!(pw.len(), 32);
+        assert!(pw.is_ascii());
+    }
+}

--- a/server/src/cli_commands/mod.rs
+++ b/server/src/cli_commands/mod.rs
@@ -1,0 +1,3 @@
+pub mod edit_user;
+pub mod migrate;
+pub(crate) mod util;

--- a/server/src/cli_commands/util.rs
+++ b/server/src/cli_commands/util.rs
@@ -1,0 +1,11 @@
+pub fn generate_random_password() -> String {
+    const CHARSET: &[u8] = b"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789!@#$%&*";
+    let mut bytes = [0u8; 32];
+
+    getrandom::fill(&mut bytes).expect("getrandom failed -- is the OS entropy source broken?");
+    // biased as 255 does not evenly divide into CHARSET.len(), but good enough for our purposes
+    bytes
+        .iter()
+        .map(|b| CHARSET[(*b as usize) % CHARSET.len()] as char)
+        .collect()
+}

--- a/server/src/interfaces.rs
+++ b/server/src/interfaces.rs
@@ -119,6 +119,12 @@ impl PublicSuffix {
     }
 }
 
+impl PublicSuffix {
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
 impl<'de> Deserialize<'de> for PublicSuffix {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -2,6 +2,7 @@ mod api;
 mod auth;
 mod auth_cache;
 mod captcha;
+mod cli_commands;
 mod error;
 mod interfaces;
 mod rate_limit;
@@ -50,6 +51,40 @@ struct Args {
     /// Use in-memory dummy providers for everything (ignores --config).
     #[arg(long)]
     dummy: bool,
+    #[command(subcommand)]
+    command: Option<Command>,
+}
+
+#[derive(clap::Subcommand, Debug)]
+enum Command {
+    /// Import users + DNS records from the upstream DNS provider into the local database.
+    /// Prompts for credentials for each new user found upstream. Will ask to delete users that are no longer present in the upstream DNS provider.
+    Migrate {
+        /// Don't actually create users or import records -- just show what would happen.
+        #[arg(long)]
+        dry_run: bool,
+    },
+    /// Edit an existing user's fields (email, state, password, username).
+    /// Does not block the user from making racing changes while running this! use with care
+    EditUser {
+        /// Username of the user to edit
+        username: String,
+        /// Set a new email address
+        #[arg(long)]
+        email: Option<String>,
+        /// Set account state (pending, active, inactive, banned)
+        #[arg(long)]
+        state: Option<fckn_gay_user_database::UserState>,
+        /// Reset password to a random one (prints the new password)
+        #[arg(long)]
+        reset_password: bool,
+        /// Rename the user (updates username + all DNS records)
+        #[arg(long)]
+        rename: Option<String>,
+        /// Dry run -- don't actually change anything
+        #[arg(long)]
+        dry_run: bool,
+    },
 }
 
 #[tokio::main]
@@ -67,55 +102,94 @@ async fn main() -> Result<()> {
     if args.dummy {
         log::info!("--dummy mode: using in-memory providers for everything, ignoring config file");
     }
-    let listener = tokio::net::TcpListener::bind(&config.address)
-        .await
-        .context("Failed to bind to address")?;
-    log::info!("starting server on http://{}", config.address);
+
+    let address = config.address.clone();
     let interfaces = Interfaces::new(config)?;
 
-    // Each module owns its middleware (auth, rate limiting, etc).
-    // main.rs just wires the routers together.
-    let app = auth::router(interfaces.clone())
-        .merge(axum::Router::new().nest(
-            "/user",
-            user_routes::router(interfaces.clone(), "server/static/u"),
-        ))
-        .merge(axum::Router::new().nest("/api", api::router(interfaces.clone())))
-        .route(
-            "/api/captcha-config",
-            axum::routing::get(captcha::captcha_config),
-        )
-        // WASM files with correct MIME type
-        .merge(axum::Router::new().route(
-            "/fckn_gay_validation_bg.wasm",
-            axum::routing::get(|| async {
-                let wasm_data = std::fs::read("server/static/fckn_gay_validation_bg.wasm")
-                    .unwrap_or_else(|_| Vec::new());
-                Response::builder()
-                    .header("content-type", "application/wasm")
-                    .header("content-length", wasm_data.len())
-                    .body(Body::from(wasm_data))
-                    .unwrap()
-            }),
-        ))
-        // static files, /, favicon, css etc
-        .fallback_service(
-            tower_http::services::ServeDir::new("server/static")
-                .append_index_html_on_directories(true)
-                .precompressed_gzip()
-                .precompressed_br()
-                .precompressed_deflate()
-                .precompressed_zstd(),
-        )
-        .layer(CatchPanicLayer::custom(silly_panic_handler))
-        .with_state(interfaces);
+    match args.command {
+        Some(Command::Migrate { dry_run }) => {
+            cli_commands::migrate::run(
+                &interfaces.dns,
+                &interfaces.user_database,
+                &interfaces.hostname,
+                dry_run,
+            )
+            .await?;
+        }
+        Some(Command::EditUser {
+            username,
+            email,
+            state,
+            reset_password,
+            rename,
+            dry_run,
+        }) => {
+            cli_commands::edit_user::run(
+                &interfaces.dns,
+                &interfaces.user_database,
+                &interfaces.hostname,
+                &username,
+                cli_commands::edit_user::EditUserOpts {
+                    email,
+                    state,
+                    reset_password,
+                    rename,
+                    dry_run,
+                },
+            )
+            .await?;
+        }
+        None => {
+            let listener = tokio::net::TcpListener::bind(&address)
+                .await
+                .context("Failed to bind to address")?;
+            log::info!("starting server on http://{address}");
 
-    axum::serve(
-        listener,
-        app.into_make_service_with_connect_info::<SocketAddr>(),
-    )
-    .await
-    .context("Failed to start server")?;
+            // Each module owns its middleware (auth, rate limiting, etc).
+            // main.rs just wires the routers together.
+            let app = auth::router(interfaces.clone())
+                .merge(axum::Router::new().nest(
+                    "/user",
+                    user_routes::router(interfaces.clone(), "server/static/u"),
+                ))
+                .merge(axum::Router::new().nest("/api", api::router(interfaces.clone())))
+                .route(
+                    "/api/captcha-config",
+                    axum::routing::get(captcha::captcha_config),
+                )
+                // WASM files with correct MIME type
+                .merge(axum::Router::new().route(
+                    "/fckn_gay_validation_bg.wasm",
+                    axum::routing::get(|| async {
+                        let wasm_data = std::fs::read("server/static/fckn_gay_validation_bg.wasm")
+                            .unwrap_or_else(|_| Vec::new());
+                        Response::builder()
+                            .header("content-type", "application/wasm")
+                            .header("content-length", wasm_data.len())
+                            .body(Body::from(wasm_data))
+                            .unwrap()
+                    }),
+                ))
+                // static files, /, favicon, css etc
+                .fallback_service(
+                    tower_http::services::ServeDir::new("server/static")
+                        .append_index_html_on_directories(true)
+                        .precompressed_gzip()
+                        .precompressed_br()
+                        .precompressed_deflate()
+                        .precompressed_zstd(),
+                )
+                .layer(CatchPanicLayer::custom(silly_panic_handler))
+                .with_state(interfaces);
+
+            axum::serve(
+                listener,
+                app.into_make_service_with_connect_info::<SocketAddr>(),
+            )
+            .await
+            .context("Failed to start server")?;
+        }
+    }
 
     Ok(())
 }

--- a/user-database/implementors/diesel/src/lib.rs
+++ b/user-database/implementors/diesel/src/lib.rs
@@ -2,7 +2,7 @@ mod models;
 mod schema;
 use diesel::prelude::*;
 use fckn_gay_user_database_interface::{
-    DnsRecord, DnsRecordId, PasswordHash, UserDatabase, UserEntry, Uuid,
+    DnsRecord, DnsRecordId, PasswordHash, UserDatabase, UserEntry, UserFields, UserState, Uuid,
 };
 
 #[derive(Debug, serde::Deserialize)]
@@ -258,6 +258,88 @@ impl UserDatabase for Database {
         Ok(record)
     }
 
+    async fn update_entry<F>(&self, user_id: Uuid, f: F) -> Result<(), Self::Error>
+    where
+        F: FnOnce(&mut UserFields) + Send,
+    {
+        let user_bytes = user_id.to_bytes_le();
+        let mut conn = self.connection.lock().await;
+        let raw = schema::users::dsl::users
+            .filter(schema::users::id.eq(&user_bytes))
+            .first::<models::RawUser>(&mut *conn)?;
+        let mut entry = UserEntry::from(raw);
+        f(&mut entry.fields);
+
+        let state_i32: i32 = match entry.fields.state {
+            UserState::Pending => 0,
+            UserState::Active => 1,
+            UserState::Inactive => 2,
+            UserState::Banned => 3,
+        };
+
+        diesel::update(schema::users::dsl::users.filter(schema::users::id.eq(&user_bytes)))
+            .set((
+                schema::users::username.eq(&entry.fields.username),
+                schema::users::email.eq(&entry.fields.email),
+                schema::users::password_hash.eq(entry.fields.password_hash.into_string()),
+                schema::users::state.eq(state_i32),
+                schema::users::last_login.eq(entry.fields.last_login),
+            ))
+            .execute(&mut *conn)?;
+        Ok(())
+    }
+
+    async fn update_user_email(&self, user_id: Uuid, new_email: &str) -> Result<(), Self::Error> {
+        let user_bytes = user_id.to_bytes_le();
+        let updated =
+            diesel::update(schema::users::dsl::users.filter(schema::users::id.eq(&user_bytes)))
+                .set(schema::users::email.eq(new_email))
+                .execute(&mut *self.connection.lock().await)?;
+        if updated == 0 {
+            Err(Error::Other(
+                "User not found, can't update email".to_string(),
+            ))
+        } else {
+            Ok(())
+        }
+    }
+
+    async fn update_user_state(&self, user_id: Uuid, state: UserState) -> Result<(), Self::Error> {
+        let state_i32: i32 = match state {
+            UserState::Pending => 0,
+            UserState::Active => 1,
+            UserState::Inactive => 2,
+            UserState::Banned => 3,
+        };
+        let user_bytes = user_id.to_bytes_le();
+        let updated =
+            diesel::update(schema::users::dsl::users.filter(schema::users::id.eq(&user_bytes)))
+                .set(schema::users::state.eq(state_i32))
+                .execute(&mut *self.connection.lock().await)?;
+        if updated == 0 {
+            Err(Error::Other(
+                "User not found, can't update state".to_string(),
+            ))
+        } else {
+            Ok(())
+        }
+    }
+
+    async fn update_username(&self, user_id: Uuid, new_username: &str) -> Result<(), Self::Error> {
+        let user_bytes = user_id.to_bytes_le();
+        let updated =
+            diesel::update(schema::users::dsl::users.filter(schema::users::id.eq(&user_bytes)))
+                .set(schema::users::username.eq(new_username))
+                .execute(&mut *self.connection.lock().await)?;
+        if updated == 0 {
+            Err(Error::Other(
+                "User not found, can't update username".to_string(),
+            ))
+        } else {
+            Ok(())
+        }
+    }
+
     async fn update_user_password(
         &self,
         user_id: Uuid,
@@ -277,6 +359,13 @@ impl UserDatabase for Database {
         }
     }
 
+    async fn list_all_users(&self) -> Result<Vec<UserEntry>, Self::Error> {
+        use self::schema::users::dsl::users;
+        let mut conn = self.connection.lock().await;
+        let all = users.load::<models::RawUser>(&mut *conn)?;
+        Ok(all.into_iter().map(UserEntry::from).collect())
+    }
+
     async fn get_user_by_username_or_email(
         &self,
         username_or_email: &str,
@@ -291,8 +380,9 @@ impl UserDatabase for Database {
             )
             .load::<models::RawUser>(&mut *conn)?;
         if user.len() > 1 {
-            //this should never happen, usernames and emails should be unique
-            // and a valid email should never be a valid username
+            // this can happen if querying by email and multiple users have the same email
+            // should not really happen but happens when migrating as there are some users with
+            // multiple accounts, like me.
             return Err(Error::MultipleUsersFound);
         }
         Ok(user.into_iter().next().map(UserEntry::from))

--- a/user-database/implementors/diesel/src/models.rs
+++ b/user-database/implementors/diesel/src/models.rs
@@ -40,12 +40,14 @@ impl From<RawUser> for fckn_gay_user_database_interface::UserEntry {
         };
         Self {
             id,
-            username,
-            email,
-            password_hash,
-            state,
-            created_at,
-            last_login,
+            fields: fckn_gay_user_database_interface::UserFields {
+                username,
+                email,
+                password_hash,
+                state,
+                created_at,
+                last_login,
+            },
         }
     }
 }

--- a/user-database/implementors/dummy/src/lib.rs
+++ b/user-database/implementors/dummy/src/lib.rs
@@ -1,8 +1,8 @@
 use std::collections::BTreeMap;
 
 use fckn_gay_user_database_interface::{
-    DatabaseDnsRecord, DnsRecord, DnsRecordId, PasswordHash, UserDatabase, UserEntry, UserState,
-    Uuid,
+    DatabaseDnsRecord, DnsRecord, DnsRecordId, PasswordHash, UserDatabase, UserEntry, UserFields,
+    UserState, Uuid,
 };
 
 /// a simple user database parsed directly from the configuration file.
@@ -48,12 +48,14 @@ impl UserDatabase for Database {
                 let password_hash = PasswordHash::new(&password);
                 UserEntry {
                     id: Uuid::new_v4(),
-                    username: username.clone(),
-                    password_hash,
-                    email: format!("\"{username}\"@example.com"),
-                    state: UserState::Active,
-                    created_at: chrono::Utc::now().naive_utc(),
-                    last_login: None,
+                    fields: UserFields {
+                        username: username.clone(),
+                        password_hash,
+                        email: format!("\"{username}\"@example.com"),
+                        state: UserState::Active,
+                        created_at: chrono::Utc::now().naive_utc(),
+                        last_login: None,
+                    },
                 }
             })
             .collect();
@@ -108,12 +110,14 @@ impl UserDatabase for Database {
         let password_hash = PasswordHash::new(password);
         lock.push(UserEntry {
             id: user_id,
-            username: username.to_string(),
-            password_hash,
-            email: email.to_string(),
-            state: UserState::Pending,
-            created_at: chrono::Utc::now().naive_utc(),
-            last_login: None,
+            fields: UserFields {
+                username: username.to_string(),
+                password_hash,
+                email: email.to_string(),
+                state: UserState::Pending,
+                created_at: chrono::Utc::now().naive_utc(),
+                last_login: None,
+            },
         });
 
         Ok(user_id)
@@ -122,9 +126,9 @@ impl UserDatabase for Database {
     async fn activate_user(&self, uuid: Uuid) -> Result<(), Self::Error> {
         let mut lock = self.users.lock().await;
         if let Some(user) = lock.iter_mut().find(|user| user.id == uuid)
-            && user.state == UserState::Pending
+            && user.fields.state == UserState::Pending
         {
-            user.state = UserState::Active;
+            user.fields.state = UserState::Active;
             return Ok(());
         }
         Err(Error::UserNotFound)
@@ -213,18 +217,32 @@ impl UserDatabase for Database {
         Ok(entry.provider_key)
     }
 
-    async fn update_user_password(
-        &self,
-        user_id: Uuid,
-        password: PasswordHash,
-    ) -> Result<(), Self::Error> {
+    async fn update_entry<F>(&self, user_id: Uuid, f: F) -> Result<(), Self::Error>
+    where
+        F: FnOnce(&mut UserFields) + Send,
+    {
         let mut lock = self.users.lock().await;
         if let Some(user) = lock.iter_mut().find(|u| u.id == user_id) {
-            user.password_hash = password;
+            f(&mut user.fields);
             Ok(())
         } else {
             Err(Error::UserNotFound)
         }
+    }
+
+    async fn delete_user(&self, username: &str) -> Result<(), Self::Error> {
+        let mut lock = self.users.lock().await;
+        let before = lock.len();
+        lock.retain(|u| u.username != username);
+        if lock.len() == before {
+            Err(Error::UserNotFound)
+        } else {
+            Ok(())
+        }
+    }
+
+    async fn list_all_users(&self) -> Result<Vec<UserEntry>, Self::Error> {
+        Ok(self.users.lock().await.clone())
     }
 
     async fn get_user_by_username_or_email(

--- a/user-database/interface/src/lib.rs
+++ b/user-database/interface/src/lib.rs
@@ -1,3 +1,5 @@
+use std::{fmt, str::FromStr};
+
 use serde::{Deserialize, Serialize};
 pub use uuid::Uuid;
 
@@ -31,10 +33,36 @@ pub enum UserState {
     Banned,
 }
 
-// uuid field is also the key for activating an account
+impl fmt::Display for UserState {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            UserState::Pending => write!(f, "pending"),
+            UserState::Active => write!(f, "active"),
+            UserState::Inactive => write!(f, "inactive"),
+            UserState::Banned => write!(f, "banned"),
+        }
+    }
+}
+
+impl FromStr for UserState {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.to_ascii_lowercase().as_str() {
+            "pending" => Ok(UserState::Pending),
+            "active" => Ok(UserState::Active),
+            "inactive" => Ok(UserState::Inactive),
+            "banned" => Ok(UserState::Banned),
+            other => Err(format!(
+                "unknown user state '{other}' (expected: pending, active, inactive, banned)"
+            )),
+        }
+    }
+}
+
+/// The mutable fields of a user entry -- everything except the immutable UUID.
 #[derive(Debug, Clone)]
-pub struct UserEntry {
-    pub id: Uuid,
+pub struct UserFields {
     pub username: String,
     pub password_hash: PasswordHash,
     pub email: String,
@@ -43,7 +71,7 @@ pub struct UserEntry {
     pub last_login: Option<chrono::NaiveDateTime>,
 }
 
-impl UserEntry {
+impl UserFields {
     pub fn is_active(&self) -> bool {
         matches!(self.state, UserState::Active)
     }
@@ -55,6 +83,20 @@ impl UserEntry {
     pub fn is_valid(&self, username: &str, password: &str) -> bool {
         // order is important here for short-circuiting to avoid unnecessary hashing
         self.is_active() && self.username == username && self.password_hash.validate(password)
+    }
+}
+
+// uuid field is also the key for activating an account
+#[derive(Debug, Clone)]
+pub struct UserEntry {
+    pub id: Uuid,
+    pub fields: UserFields,
+}
+
+impl std::ops::Deref for UserEntry {
+    type Target = UserFields;
+    fn deref(&self) -> &UserFields {
+        &self.fields
     }
 }
 
@@ -138,18 +180,59 @@ pub trait UserDatabase {
         async { todo!("delete_user is not implemented") }
     }
 
+    /// Returns all users in the database. Used by admin tooling (migration, etc).
+    fn list_all_users(&self) -> impl Future<Output = Result<Vec<UserEntry>, Self::Error>> {
+        async { todo!("list_all_users is not implemented") }
+    }
+
     #[allow(unused_variables)]
     fn activate_user(&self, uuid: Uuid) -> impl Future<Output = Result<(), Self::Error>> {
         async { todo!("activate_user is not implemented") }
     }
 
+    /// Generic entry update: loads the user by UUID, applies a closure to its
+    /// mutable fields, and persists the result. Implementors should override for
+    /// efficiency, but the default panics with `todo!`.
     #[allow(unused_variables)]
+    fn update_entry<F>(&self, user_id: Uuid, f: F) -> impl Future<Output = Result<(), Self::Error>>
+    where
+        F: FnOnce(&mut UserFields) + Send,
+    {
+        async { todo!("update_entry is not implemented") }
+    }
+
+    fn update_user_email(
+        &self,
+        user_id: Uuid,
+        email: &str,
+    ) -> impl Future<Output = Result<(), Self::Error>> {
+        let email = email.to_string();
+        self.update_entry(user_id, move |f| f.email = email)
+    }
+
+    fn update_user_state(
+        &self,
+        user_id: Uuid,
+        state: UserState,
+    ) -> impl Future<Output = Result<(), Self::Error>> {
+        self.update_entry(user_id, move |f| f.state = state)
+    }
+
+    fn update_username(
+        &self,
+        user_id: Uuid,
+        new_username: &str,
+    ) -> impl Future<Output = Result<(), Self::Error>> {
+        let new_username = new_username.to_string();
+        self.update_entry(user_id, move |f| f.username = new_username)
+    }
+
     fn update_user_password(
         &self,
         user_id: Uuid,
         password: PasswordHash,
     ) -> impl Future<Output = Result<(), Self::Error>> {
-        async { todo!("update_user_password is not implemented") }
+        self.update_entry(user_id, move |f| f.password_hash = password)
     }
 
     #[allow(unused_variables)]

--- a/user-database/src/lib.rs
+++ b/user-database/src/lib.rs
@@ -12,7 +12,8 @@ pub use fckn_gay_user_database_diesel::Database as DieselDatabase;
 #[cfg(feature = "dummy")]
 pub use fckn_gay_user_database_dummy::Database as DummyDatabase;
 pub use fckn_gay_user_database_interface::{
-    DatabaseDnsRecord, DnsRecordId, PasswordHash, UserDatabase as Interface, Uuid,
+    DatabaseDnsRecord, DnsRecordId, PasswordHash, UserDatabase as Interface, UserEntry, UserFields,
+    UserState, Uuid,
 };
 use serde::{Deserialize, Deserializer};
 
@@ -457,6 +458,108 @@ impl Interface for Database {
             #[cfg(feature = "diesel")]
             Database::Diesel(db) => db
                 .get_dns_record_provider_key(user_id, record_id)
+                .await
+                .map_err(Self::Error::Diesel),
+        }
+    }
+
+    async fn delete_user(&self, username: &str) -> Result<(), Self::Error> {
+        match self {
+            #[cfg(feature = "dummy")]
+            Database::Dummy(db) => db.delete_user(username).await.map_err(Self::Error::Dummy),
+            #[cfg(feature = "csv")]
+            Database::Csv(db) => db.delete_user(username).await.map_err(Self::Error::Csv),
+            #[cfg(feature = "diesel")]
+            Database::Diesel(db) => db.delete_user(username).await.map_err(Self::Error::Diesel),
+        }
+    }
+
+    async fn list_all_users(&self) -> Result<Vec<UserEntry>, Self::Error> {
+        match self {
+            #[cfg(feature = "dummy")]
+            Database::Dummy(db) => db.list_all_users().await.map_err(Self::Error::Dummy),
+            #[cfg(feature = "csv")]
+            Database::Csv(db) => db.list_all_users().await.map_err(Self::Error::Csv),
+            #[cfg(feature = "diesel")]
+            Database::Diesel(db) => db.list_all_users().await.map_err(Self::Error::Diesel),
+        }
+    }
+
+    async fn update_entry<F>(&self, user_id: Uuid, f: F) -> Result<(), Self::Error>
+    where
+        F: FnOnce(&mut UserFields) + Send,
+    {
+        match self {
+            #[cfg(feature = "dummy")]
+            Database::Dummy(db) => db
+                .update_entry(user_id, f)
+                .await
+                .map_err(Self::Error::Dummy),
+            #[cfg(feature = "csv")]
+            Database::Csv(db) => db.update_entry(user_id, f).await.map_err(Self::Error::Csv),
+            #[cfg(feature = "diesel")]
+            Database::Diesel(db) => db
+                .update_entry(user_id, f)
+                .await
+                .map_err(Self::Error::Diesel),
+        }
+    }
+
+    async fn update_user_email(&self, user_id: Uuid, email: &str) -> Result<(), Self::Error> {
+        match self {
+            #[cfg(feature = "dummy")]
+            Database::Dummy(db) => db
+                .update_user_email(user_id, email)
+                .await
+                .map_err(Self::Error::Dummy),
+            #[cfg(feature = "csv")]
+            Database::Csv(db) => db
+                .update_user_email(user_id, email)
+                .await
+                .map_err(Self::Error::Csv),
+            #[cfg(feature = "diesel")]
+            Database::Diesel(db) => db
+                .update_user_email(user_id, email)
+                .await
+                .map_err(Self::Error::Diesel),
+        }
+    }
+
+    async fn update_user_state(&self, user_id: Uuid, state: UserState) -> Result<(), Self::Error> {
+        match self {
+            #[cfg(feature = "dummy")]
+            Database::Dummy(db) => db
+                .update_user_state(user_id, state)
+                .await
+                .map_err(Self::Error::Dummy),
+            #[cfg(feature = "csv")]
+            Database::Csv(db) => db
+                .update_user_state(user_id, state)
+                .await
+                .map_err(Self::Error::Csv),
+            #[cfg(feature = "diesel")]
+            Database::Diesel(db) => db
+                .update_user_state(user_id, state)
+                .await
+                .map_err(Self::Error::Diesel),
+        }
+    }
+
+    async fn update_username(&self, user_id: Uuid, new_username: &str) -> Result<(), Self::Error> {
+        match self {
+            #[cfg(feature = "dummy")]
+            Database::Dummy(db) => db
+                .update_username(user_id, new_username)
+                .await
+                .map_err(Self::Error::Dummy),
+            #[cfg(feature = "csv")]
+            Database::Csv(db) => db
+                .update_username(user_id, new_username)
+                .await
+                .map_err(Self::Error::Csv),
+            #[cfg(feature = "diesel")]
+            Database::Diesel(db) => db
+                .update_username(user_id, new_username)
                 .await
                 .map_err(Self::Error::Diesel),
         }


### PR DESCRIPTION
adds two cli tools for editing users and spinning up a server from an upstream dns

closes #75 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Introduces new CLI flows that can create/delete users and delete/add upstream DNS records during rename/migration, so mistakes or edge cases can cause data loss or dangling records.
> 
> **Overview**
> Adds `migrate` and `edit-user` CLI subcommands to the server binary for admin user/record management, including dry-run support.
> 
> `migrate` imports upstream DNS records into the local user DB (creating/activating missing users interactively) and optionally deletes local users/records that no longer exist upstream; `edit-user` can update email/state, reset passwords, and rename users while migrating their DNS records via add-then-delete with retries.
> 
> Extends the user-database interface and implementations to support `list_all_users` and targeted user field updates (`update_entry`, `update_user_email`, `update_user_state`, `update_username`), and refactors `UserEntry` to encapsulate mutable `UserFields` plus adds `UserState` string parsing/printing and a `PublicSuffix::as_str` helper.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f0ef39da580c321f10522af713df30383444ecce. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->