### PR TITLE
🧹 implement update_record for porkbun and use update_record in edit_user

### DIFF
--- a/dns/implementors/porkbun/src/lib.rs
+++ b/dns/implementors/porkbun/src/lib.rs
@@ -46,18 +46,71 @@ impl PorkbunDns {
             fckn_gay_dns_interface::RecordType::TXT => porkbun_api::DnsRecordType::TXT,
         }
     }
+
+    fn convert_record_type_from_porkbun(
+        record_type: porkbun_api::DnsRecordType,
+    ) -> fckn_gay_dns_interface::RecordType {
+        match record_type {
+            porkbun_api::DnsRecordType::A => fckn_gay_dns_interface::RecordType::A,
+            porkbun_api::DnsRecordType::AAAA => fckn_gay_dns_interface::RecordType::AAAA,
+            porkbun_api::DnsRecordType::ALIAS => fckn_gay_dns_interface::RecordType::ALIAS,
+            porkbun_api::DnsRecordType::CAA => fckn_gay_dns_interface::RecordType::CAA,
+            porkbun_api::DnsRecordType::CNAME => fckn_gay_dns_interface::RecordType::CNAME,
+            porkbun_api::DnsRecordType::HTTPS => fckn_gay_dns_interface::RecordType::HTTPS,
+            porkbun_api::DnsRecordType::MX => fckn_gay_dns_interface::RecordType::MX,
+            porkbun_api::DnsRecordType::NS => fckn_gay_dns_interface::RecordType::NS,
+            porkbun_api::DnsRecordType::SRV => fckn_gay_dns_interface::RecordType::SRV,
+            porkbun_api::DnsRecordType::SVCB => fckn_gay_dns_interface::RecordType::SVCB,
+            porkbun_api::DnsRecordType::TLSA => fckn_gay_dns_interface::RecordType::TLSA,
+            porkbun_api::DnsRecordType::TXT => fckn_gay_dns_interface::RecordType::TXT,
+        }
+    }
+
+    /// Validate subdomain and build a `CreateOrEditDnsRecord` command from our `Record` type.
+    fn build_cmd<'a>(
+        &self,
+        record: &'a Record,
+    ) -> Result<(&'a str, porkbun_api::CreateOrEditDnsRecord<'a>), Error> {
+        let subdomain = record
+            .name
+            .strip_suffix(self.domain.as_str())
+            .ok_or_else(|| Error::SubdomainMismatch {
+                name: record.name.clone(),
+                domain: self.domain.clone(),
+            })?;
+        let subdomain = subdomain.strip_suffix('.').unwrap_or(subdomain);
+        if !subdomain.is_ascii() {
+            return Err(Error::NonAsciiSubdomain {
+                name: record.name.clone(),
+            });
+        }
+        let cmd = porkbun_api::CreateOrEditDnsRecord {
+            subdomain: Some(subdomain),
+            record_type: Self::convert_record_type_to_porkbun(record.record_type),
+            content: record.content.clone().into(),
+            ttl: Some(record.ttl_seconds.into()),
+            prio: record.priority.unwrap_or(0).into(),
+        };
+        Ok((subdomain, cmd))
+    }
 }
 
 pub enum Error {
     Api(ApiError<DefaultTransportError>),
-    Other(String),
+    SubdomainMismatch { name: String, domain: String },
+    NonAsciiSubdomain { name: String },
 }
 
 impl Debug for Error {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            Error::Api(e) => write!(f, "Porkbun API returned an error: {e:?}"),
-            Error::Other(s) => write!(f, "{s}"),
+            Error::Api(e) => write!(f, "Porkbun API error: {e:?}"),
+            Error::SubdomainMismatch { name, domain } => {
+                write!(f, "'{name}' doesn't end with domain '{domain}'")
+            }
+            Error::NonAsciiSubdomain { name } => {
+                write!(f, "'{name}' contains non-ASCII characters")
+            }
         }
     }
 }
@@ -66,7 +119,12 @@ impl Display for Error {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Error::Api(_) => write!(f, "Porkbun API returned an error"),
-            Error::Other(s) => write!(f, "{s}"),
+            Error::SubdomainMismatch { name, domain } => {
+                write!(f, "'{name}' doesn't end with domain '{domain}'")
+            }
+            Error::NonAsciiSubdomain { name } => {
+                write!(f, "'{name}' contains non-ASCII characters")
+            }
         }
     }
 }
@@ -75,7 +133,7 @@ impl std::error::Error for Error {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {
             Error::Api(e) => Some(e),
-            Error::Other(_) => None,
+            _ => None,
         }
     }
 }
@@ -91,7 +149,6 @@ impl Dns for PorkbunDns {
     type Error = Error;
     type Key = String;
 
-    /// Creates a new instance of the DNS provider with the given configuration.
     fn new(config: Self::Config) -> Result<Self, Self::Error> {
         let Config {
             domain,
@@ -105,33 +162,12 @@ impl Dns for PorkbunDns {
         Ok(PorkbunDns { client, domain })
     }
 
-    /// Adds a DNS record to the provider.
     async fn add_record(&self, record: Record) -> Result<Self::Key, Self::Error> {
-        let Some(subdomain) = record.name.strip_suffix(self.domain.as_str()) else {
-            return Err(Error::Other(format!(
-                "The subdomain {} does not end with the domain {}",
-                record.name, self.domain
-            )));
-        };
-        let subdomain = subdomain.strip_suffix('.').unwrap_or(subdomain);
-        if !subdomain.is_ascii() {
-            return Err(Error::Other(format!(
-                "The domain {} contains non-ascii characters",
-                record.name
-            )));
-        }
-        let cmd = porkbun_api::CreateOrEditDnsRecord {
-            subdomain: Some(subdomain),
-            record_type: Self::convert_record_type_to_porkbun(record.record_type),
-            content: record.content.into(),
-            ttl: Some(record.ttl_seconds.into()),
-            prio: record.priority.unwrap_or(0).into(),
-        };
-        let response = self.client.create(&self.domain, cmd).await?;
-        Ok(response)
+        let (_, cmd) = self.build_cmd(&record)?;
+        let id = self.client.create(&self.domain, cmd).await?;
+        Ok(id)
     }
 
-    /// Deletes a DNS record from the provider.
     async fn delete_record(&self, key: Self::Key) -> Result<(), Self::Error> {
         self.client
             .delete(&self.domain, &key)
@@ -139,7 +175,6 @@ impl Dns for PorkbunDns {
             .map_err(Error::from)
     }
 
-    /// Lists all DNS records for a domain.
     async fn list_records(&self) -> Result<Vec<(Self::Key, Record)>, Self::Error> {
         let records = self.client.get_all(&self.domain).await?;
         Ok(records
@@ -149,42 +184,7 @@ impl Dns for PorkbunDns {
                     r.id.clone(),
                     Record {
                         name: r.name,
-                        record_type: match r.record_type {
-                            porkbun_api::DnsRecordType::A => fckn_gay_dns_interface::RecordType::A,
-                            porkbun_api::DnsRecordType::AAAA => {
-                                fckn_gay_dns_interface::RecordType::AAAA
-                            }
-                            porkbun_api::DnsRecordType::ALIAS => {
-                                fckn_gay_dns_interface::RecordType::ALIAS
-                            }
-                            porkbun_api::DnsRecordType::CAA => {
-                                fckn_gay_dns_interface::RecordType::CAA
-                            }
-                            porkbun_api::DnsRecordType::CNAME => {
-                                fckn_gay_dns_interface::RecordType::CNAME
-                            }
-                            porkbun_api::DnsRecordType::HTTPS => {
-                                fckn_gay_dns_interface::RecordType::HTTPS
-                            }
-                            porkbun_api::DnsRecordType::MX => {
-                                fckn_gay_dns_interface::RecordType::MX
-                            }
-                            porkbun_api::DnsRecordType::NS => {
-                                fckn_gay_dns_interface::RecordType::NS
-                            }
-                            porkbun_api::DnsRecordType::SRV => {
-                                fckn_gay_dns_interface::RecordType::SRV
-                            }
-                            porkbun_api::DnsRecordType::SVCB => {
-                                fckn_gay_dns_interface::RecordType::SVCB
-                            }
-                            porkbun_api::DnsRecordType::TLSA => {
-                                fckn_gay_dns_interface::RecordType::TLSA
-                            }
-                            porkbun_api::DnsRecordType::TXT => {
-                                fckn_gay_dns_interface::RecordType::TXT
-                            }
-                        },
+                        record_type: Self::convert_record_type_from_porkbun(r.record_type),
                         content: r.content,
                         ttl_seconds: r.ttl as u32,
                         priority: Some(r.prio as u16),
@@ -194,12 +194,9 @@ impl Dns for PorkbunDns {
             .collect())
     }
 
-    #[allow(unused_variables)]
-    /// Updates a DNS record
     async fn update_record(&self, key: Self::Key, record: Record) -> Result<(), Self::Error> {
-        // TODO: Implement update_record for Porkbun provider
-        Err(Error::Other(
-            "update_record not implemented for Porkbun provider".to_string(),
-        ))
+        let (_, cmd) = self.build_cmd(&record)?;
+        self.client.edit(&self.domain, &key, cmd).await?;
+        Ok(())
     }
 }

--- a/server/src/cli_commands/edit_user.rs
+++ b/server/src/cli_commands/edit_user.rs
@@ -118,10 +118,13 @@ pub async fn run(
     Ok(())
 }
 
-/// Rename a user: update username in DB + migrate all their DNS records upstream.
+/// Rename a user: update username in DB + update all their DNS records in-place.
 ///
-/// Since Porkbun doesn't support updating records in-place, we do delete + add per record.
-/// Failed upstream adds go to a retry queue with exponential backoff (1s, 2s, 4s).
+/// Each record is processed independently. For every record we:
+///   1. Update the record upstream (retries with backoff, fatal on failure)
+///   2. Update the record in the DB (retries with backoff, rolls back step 1 on failure)
+///
+/// All steps (including rollback) use exponential backoff: 1 s → 2 s → 4 s → 16 s.
 async fn rename_user(
     dns: &Dns,
     user_db: &UserDatabase,
@@ -179,7 +182,6 @@ async fn rename_user(
 
     let mut succeeded = 0u32;
     let mut failed = 0u32;
-    let mut dangling_old = 0u32;
     let mut failed_names: Vec<String> = Vec::new();
 
     for rec in &db_records {
@@ -189,103 +191,84 @@ async fn rename_user(
 
         eprintln!("  📝 {} -> {}", rec.record.name, new_record.name);
 
-        // 1. add new record upstream (fatal — nothing mutated yet, safe to skip)
-        let mut add_upstream = dns.add_record(new_record.clone()).await;
-        for &secs in BACKOFFS {
-            if add_upstream.is_ok() {
-                break;
-            }
-            eprintln!("    ⏳ retrying add upstream after {secs}s...");
-            tokio::time::sleep(std::time::Duration::from_secs(secs)).await;
-            add_upstream = dns.add_record(new_record.clone()).await;
-        }
-        let new_key = match add_upstream {
-            Ok(key) => key,
+        let provider_key: fckn_gay_dns::Key = match rec.provider_key.parse() {
+            Ok(k) => k,
             Err(e) => {
-                eprintln!("    ❌ gave up adding '{}' upstream: {e}", new_record.name);
+                eprintln!(
+                    "    ❌ can't parse provider key '{}': {e} -- skipping",
+                    rec.provider_key
+                );
                 failed += 1;
                 failed_names.push(new_record.name.clone());
                 continue;
             }
         };
 
-        // 2. track new record in DB (on failure, roll back step 1)
-        let new_key_str = new_key.to_string();
-        let mut add_db = user_db
-            .add_dns_record(user_id, new_record.clone(), new_key_str.clone())
+        // 1. update record upstream (fatal — nothing mutated yet, safe to skip)
+        let mut update_upstream = dns
+            .update_record(provider_key.clone(), new_record.clone())
             .await;
         for &secs in BACKOFFS {
-            if add_db.is_ok() {
+            if update_upstream.is_ok() {
                 break;
             }
-            eprintln!("    ⏳ retrying add DB record after {secs}s...");
+            eprintln!("    ⏳ retrying update upstream after {secs}s...");
             tokio::time::sleep(std::time::Duration::from_secs(secs)).await;
-            add_db = user_db
-                .add_dns_record(user_id, new_record.clone(), new_key_str.clone())
+            update_upstream = dns
+                .update_record(provider_key.clone(), new_record.clone())
                 .await;
         }
-        if add_db.is_err() {
+        if let Err(e) = update_upstream {
             eprintln!(
-                "    ❌ couldn't track '{}' in DB -- rolling back upstream add",
+                "    ❌ gave up updating '{}' upstream: {e}",
                 new_record.name
             );
-            if let Err(e) = dns.delete_record(new_key.clone()).await {
-                eprintln!(
-                    "    ⚠️  rollback failed too: {e} -- upstream record '{}' is now untracked 💀",
-                    new_record.name
-                );
-                dangling_old += 1;
-            }
             failed += 1;
             failed_names.push(new_record.name.clone());
             continue;
         }
 
-        // 3. delete old record upstream (non-fatal — new record is already live + tracked)
-        let old_key: fckn_gay_dns::Key = match rec.provider_key.parse() {
-            Ok(k) => k,
-            Err(e) => {
+        // 2. update record in DB (on failure, roll back step 1)
+        let mut update_db = user_db
+            .update_dns_record(user_id, rec.id, new_record.clone())
+            .await;
+        for &secs in BACKOFFS {
+            if update_db.is_ok() {
+                break;
+            }
+            eprintln!("    ⏳ retrying update DB record after {secs}s...");
+            tokio::time::sleep(std::time::Duration::from_secs(secs)).await;
+            update_db = user_db
+                .update_dns_record(user_id, rec.id, new_record.clone())
+                .await;
+        }
+        if let Err(e) = update_db {
+            eprintln!(
+                "    ❌ couldn't update '{}' in DB: {e} -- rolling back upstream",
+                new_record.name
+            );
+            let mut rollback = dns
+                .update_record(provider_key.clone(), rec.record.clone())
+                .await;
+            for &secs in BACKOFFS {
+                if rollback.is_ok() {
+                    break;
+                }
+                eprintln!("    ⏳ retrying rollback after {secs}s...");
+                tokio::time::sleep(std::time::Duration::from_secs(secs)).await;
+                rollback = dns
+                    .update_record(provider_key.clone(), rec.record.clone())
+                    .await;
+            }
+            if let Err(rb_err) = rollback {
                 eprintln!(
-                    "    ⚠️  can't parse old provider key '{}': {e} -- old record may linger",
-                    rec.provider_key
+                    "    💀 rollback failed: {rb_err} -- upstream record '{}' is now out of sync with DB",
+                    new_record.name
                 );
-                dangling_old += 1;
-                succeeded += 1;
-                continue;
             }
-        };
-        let mut del_old_upstream = dns.delete_record(old_key.clone()).await;
-        for &secs in BACKOFFS {
-            if del_old_upstream.is_ok() {
-                break;
-            }
-            eprintln!("    ⏳ retrying delete old upstream after {secs}s...");
-            tokio::time::sleep(std::time::Duration::from_secs(secs)).await;
-            del_old_upstream = dns.delete_record(old_key.clone()).await;
-        }
-        if let Err(e) = del_old_upstream {
-            eprintln!(
-                "    ⚠️  couldn't delete old upstream record '{}': {e} -- may linger",
-                rec.provider_key
-            );
-            dangling_old += 1;
-        }
-
-        // 4. remove old record from DB (non-fatal — it's just stale bookkeeping)
-        let mut del_old_db = user_db.delete_dns_record(user_id, rec.id).await;
-        for &secs in BACKOFFS {
-            if del_old_db.is_ok() {
-                break;
-            }
-            eprintln!("    ⏳ retrying delete old DB record after {secs}s...");
-            tokio::time::sleep(std::time::Duration::from_secs(secs)).await;
-            del_old_db = user_db.delete_dns_record(user_id, rec.id).await;
-        }
-        if let Err(e) = del_old_db {
-            eprintln!(
-                "    ⚠️  couldn't clean up old DB record for '{}': {e} -- stale entry remains",
-                rec.record.name
-            );
+            failed += 1;
+            failed_names.push(new_record.name.clone());
+            continue;
         }
 
         succeeded += 1;
@@ -294,9 +277,6 @@ async fn rename_user(
 
     eprintln!("\n  === rename summary ===");
     eprintln!("  records renamed:   {succeeded}");
-    if dangling_old > 0 {
-        eprintln!("  old records left:  {dangling_old} (may need manual cleanup)");
-    }
     if failed > 0 {
         eprintln!("  records failed:    {failed}");
         for name in &failed_names {


### PR DESCRIPTION
Cleans up the porkbun dns implementor and implemented the update_dns function. Then uses it in the edit_user cli tool for username migrations.