### PR TITLE
Feature-gated OpenTelemetry distributed tracing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -187,7 +187,7 @@ dependencies = [
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
- "tower",
+ "tower 0.5.3",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -800,13 +800,19 @@ dependencies = [
  "fckn-gay-validation",
  "getrandom 0.3.4",
  "governor",
- "reqwest",
+ "opentelemetry",
+ "opentelemetry-otlp",
+ "opentelemetry-stdout",
+ "opentelemetry_sdk",
+ "reqwest 0.13.2",
  "serde",
  "tokio",
  "toml",
+ "tonic",
  "tower-http",
  "tower_governor",
  "tracing",
+ "tracing-opentelemetry",
  "tracing-subscriber",
  "uuid",
 ]
@@ -933,6 +939,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -942,10 +949,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
 
 [[package]]
+name = "futures-executor"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-io"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "futures-sink"
@@ -973,6 +1002,7 @@ checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-core",
  "futures-io",
+ "futures-macro",
  "futures-sink",
  "futures-task",
  "memchr",
@@ -1031,6 +1061,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "glob"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+
+[[package]]
 name = "governor"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1047,7 +1083,7 @@ dependencies = [
  "parking_lot",
  "portable-atomic",
  "quanta",
- "rand",
+ "rand 0.9.2",
  "smallvec",
  "spinning_top",
  "web-time",
@@ -1065,12 +1101,18 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http",
- "indexmap",
+ "indexmap 2.13.0",
  "slab",
  "tokio",
  "tokio-util",
  "tracing",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
@@ -1124,7 +1166,7 @@ dependencies = [
  "idna",
  "ipnet",
  "once_cell",
- "rand",
+ "rand 0.9.2",
  "ring",
  "serde",
  "thiserror 2.0.18",
@@ -1255,6 +1297,19 @@ dependencies = [
  "rustls-pki-types",
  "tokio",
  "tokio-rustls",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-timeout"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
+dependencies = [
+ "hyper",
+ "hyper-util",
+ "pin-project-lite",
+ "tokio",
  "tower-service",
 ]
 
@@ -1421,6 +1476,16 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+dependencies = [
+ "autocfg",
+ "hashbrown 0.12.3",
+]
+
+[[package]]
+name = "indexmap"
 version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
@@ -1455,6 +1520,15 @@ name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itoa"
@@ -1714,6 +1788,98 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
+name = "opentelemetry"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e87237e2775f74896f9ad219d26a2081751187eb7c9f5c58dde20a23b95d16c"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "js-sys",
+ "pin-project-lite",
+ "thiserror 2.0.18",
+ "tracing",
+]
+
+[[package]]
+name = "opentelemetry-http"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46d7ab32b827b5b495bd90fa95a6cb65ccc293555dcc3199ae2937d2d237c8ed"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "http",
+ "opentelemetry",
+ "reqwest 0.12.28",
+ "tracing",
+]
+
+[[package]]
+name = "opentelemetry-otlp"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d899720fe06916ccba71c01d04ecd77312734e2de3467fd30d9d580c8ce85656"
+dependencies = [
+ "futures-core",
+ "http",
+ "opentelemetry",
+ "opentelemetry-http",
+ "opentelemetry-proto",
+ "opentelemetry_sdk",
+ "prost",
+ "reqwest 0.12.28",
+ "thiserror 2.0.18",
+ "tokio",
+ "tonic",
+ "tracing",
+]
+
+[[package]]
+name = "opentelemetry-proto"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c40da242381435e18570d5b9d50aca2a4f4f4d8e146231adb4e7768023309b3"
+dependencies = [
+ "opentelemetry",
+ "opentelemetry_sdk",
+ "prost",
+ "tonic",
+]
+
+[[package]]
+name = "opentelemetry-stdout"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7e27d446dabd68610ef0b77d07b102ecde827a4596ea9c01a4d3811e945b286"
+dependencies = [
+ "chrono",
+ "futures-util",
+ "opentelemetry",
+ "opentelemetry_sdk",
+]
+
+[[package]]
+name = "opentelemetry_sdk"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "afdefb21d1d47394abc1ba6c57363ab141be19e27cc70d0e422b7f303e4d290b"
+dependencies = [
+ "futures-channel",
+ "futures-executor",
+ "futures-util",
+ "glob",
+ "opentelemetry",
+ "percent-encoding",
+ "rand 0.9.2",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-stream",
+ "tracing",
+]
+
+[[package]]
 name = "parking_lot"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1883,6 +2049,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "prost"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2796faa41db3ec313a31f7624d9286acf277b52de526150b7e69f3debf891ee5"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
+dependencies = [
+ "anyhow",
+ "itertools",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "psm"
 version = "0.1.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1937,7 +2126,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand",
+ "rand 0.9.2",
  "ring",
  "rustc-hash",
  "rustls",
@@ -1986,12 +2175,33 @@ checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
- "rand_chacha",
+ "rand_chacha 0.9.0",
  "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -2059,6 +2269,40 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tower 0.5.3",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
+name = "reqwest"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801"
@@ -2086,7 +2330,7 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-rustls",
- "tower",
+ "tower 0.5.3",
  "tower-http",
  "tower-service",
  "url",
@@ -2603,6 +2847,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-stream"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2642,7 +2897,7 @@ version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
- "indexmap",
+ "indexmap 2.13.0",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -2655,6 +2910,52 @@ name = "toml_write"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
+
+[[package]]
+name = "tonic"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877c5b330756d856ffcc4553ab34a5684481ade925ecc54bcd1bf02b1d0d4d52"
+dependencies = [
+ "async-trait",
+ "base64",
+ "bytes",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-timeout",
+ "hyper-util",
+ "percent-encoding",
+ "pin-project",
+ "prost",
+ "tokio",
+ "tokio-stream",
+ "tower 0.4.13",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tower"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "indexmap 1.9.3",
+ "pin-project",
+ "pin-project-lite",
+ "rand 0.8.5",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
 
 [[package]]
 name = "tower"
@@ -2694,7 +2995,7 @@ dependencies = [
  "pin-project-lite",
  "tokio",
  "tokio-util",
- "tower",
+ "tower 0.5.3",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -2724,7 +3025,7 @@ dependencies = [
  "http",
  "pin-project",
  "thiserror 2.0.18",
- "tower",
+ "tower 0.5.3",
  "tracing",
 ]
 
@@ -2770,6 +3071,24 @@ dependencies = [
  "log",
  "once_cell",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-opentelemetry"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd8e764bd6f5813fd8bebc3117875190c5b0415be8f7f8059bffb6ecd979c444"
+dependencies = [
+ "js-sys",
+ "once_cell",
+ "opentelemetry",
+ "opentelemetry_sdk",
+ "smallvec",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+ "tracing-subscriber",
+ "web-time",
 ]
 
 [[package]]
@@ -3000,7 +3319,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
 dependencies = [
  "anyhow",
- "indexmap",
+ "indexmap 2.13.0",
  "wasm-encoder",
  "wasmparser",
 ]
@@ -3013,7 +3332,7 @@ checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
  "bitflags",
  "hashbrown 0.15.5",
- "indexmap",
+ "indexmap 2.13.0",
  "semver",
 ]
 
@@ -3404,7 +3723,7 @@ checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
 dependencies = [
  "anyhow",
  "heck",
- "indexmap",
+ "indexmap 2.13.0",
  "prettyplease",
  "syn",
  "wasm-metadata",
@@ -3435,7 +3754,7 @@ checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
  "bitflags",
- "indexmap",
+ "indexmap 2.13.0",
  "log",
  "serde",
  "serde_derive",
@@ -3454,7 +3773,7 @@ checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
 dependencies = [
  "anyhow",
  "id-arena",
- "indexmap",
+ "indexmap 2.13.0",
  "log",
  "semver",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,10 @@ governor = "0.10.2"
 hickory-server = "0.25.2"
 lettre = { version = "0.11", default-features = false }
 log = "0.4"
+opentelemetry = "0.29"
+opentelemetry-otlp = { version = "0.29", features = ["grpc-tonic"] }
+opentelemetry-stdout = "0.29"
+opentelemetry_sdk = { version = "0.29", features = ["rt-tokio"] }
 password-auth = "1.0"
 porkbun-api = { version = "1.0.4", default-features = false }
 reqwest = { version = "0.13", default-features = false, features = ["form", "json", "rustls"] }
@@ -38,11 +42,13 @@ serde = { version = "1.0", features = ["derive"] }
 smallvec = "1"
 thiserror = "2.0"
 tokio = { version = "1", default-features = false }
+tonic = { version = "0.12", default-features = false }
 toml = { version = "0.8" }
 tower-http = { version = "0.6", default-features = false }
 tower_governor = { version = "0.8.0", default-features = false, features = ["axum"] }
 tracing = "0.1"
 tracing-log = "0.2"
+tracing-opentelemetry = "0.30"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 uuid = { version = "1.18.1", features = ["serde", "v4"] }
 

--- a/example_config.toml
+++ b/example_config.toml
@@ -115,3 +115,30 @@ auth_per_seconds = 60 # seconds to replenish one request slot
 # More generous limits since these are legitimate users
 api_burst_size = 30  # max requests before rate limiting kicks in
 api_per_seconds = 60 # seconds to replenish one request slot
+
+# Distributed tracing via OpenTelemetry (requires --features otel to compile).
+# If the otel feature is not enabled and provider != "disabled", the server
+# logs an error at startup but continues running without distributed tracing.
+[tracing]
+provider = "disabled"           # "disabled", "stdout" (debug), or "otlp"
+# Accept W3C traceparent/tracestate headers from incoming requests?
+# Only enable when behind a trusted proxy — otherwise anyone on the internet
+# can inject themselves into your traces. Works with and without OTel.
+trust_incoming_spans = false
+# How many hex chars of the trace ID to show in log output (1-32, default 8).
+trace_id_chars = 8
+# Max level for the OTel tracing layer, independent from [logging].level.
+# e.g. set this to "debug" to capture debug-level spans in traces while
+# keeping log output at "info". Accepts: trace, debug, info, warn, error, off.
+level = "info"
+
+# OTLP-specific configuration — only used when provider = "otlp"
+[tracing.otlp]
+endpoint = "http://localhost:4317"
+service_name = "fckn-gay-server"
+
+# Custom headers for authenticating to hosted collectors.
+# Values support all Secret formats: direct string, { env = "VAR" }, { file = "/path" }
+# [tracing.otlp.headers]
+# x-honeycomb-team = { env = "HONEYCOMB_API_KEY" }
+# Authorization = "Bearer my-grafana-token"

--- a/logging/src/lib.rs
+++ b/logging/src/lib.rs
@@ -23,7 +23,7 @@ use smallvec::SmallVec;
 use tracing::{Event, Level, Subscriber, field};
 use tracing_log::NormalizeEvent;
 use tracing_subscriber::{
-    Layer,
+    Layer, Registry,
     fmt::{FmtContext, FormatEvent, FormatFields, format::Writer, time::FormatTime},
     registry::LookupSpan,
 };
@@ -361,13 +361,19 @@ where
         }
 
         // (span_name, field_name, value) — all borrowed, no cloning
+        // Intercept `trace_id` — rendered after the {fields} block, not inside it
         let mut fields: SmallVec<[(&str, &str, &str); 16]> = SmallVec::new();
+        let mut trace_id_value: Option<&str> = None;
 
         for (span, ext) in spans.iter().zip(guards.iter()) {
             if let Some(storage) = ext.get::<SpanFieldStorage>() {
                 for (name, value) in &storage.0 {
                     if !value.is_empty() {
-                        fields.push((span.name(), *name, value.as_str()));
+                        if *name == "trace_id" && trace_id_value.is_none() {
+                            trace_id_value = Some(value.as_str());
+                        } else {
+                            fields.push((span.name(), *name, value.as_str()));
+                        }
                     }
                 }
             }
@@ -426,6 +432,16 @@ where
                 write!(writer, "{DIM}}}{RESET}")?;
             } else {
                 write!(writer, "}}")?;
+            }
+        }
+
+        // Trace ID — shown after message + fields for easy grep without
+        // disrupting level/CAUSE column alignment
+        if let Some(tid) = trace_id_value {
+            if ansi {
+                write!(writer, " {DIM}[{tid}]{RESET}")?;
+            } else {
+                write!(writer, " [{tid}]")?;
             }
         }
 
@@ -515,6 +531,29 @@ fn build_error_chain(err: &dyn std::error::Error) -> (String, SmallVec<[String; 
     let mut causes: SmallVec<[String; 4]> = SmallVec::new();
     causes.extend(parts);
     (root, causes)
+}
+
+/// Read a field value from the current span's scope (walks from current to root).
+/// Returns the first non-empty match. Used by the server to surface trace_id
+/// in error responses without depending on OTel.
+pub fn get_current_span_field(name: &str) -> Option<String> {
+    let span = tracing::Span::current();
+    span.with_subscriber(|(id, dispatch)| {
+        let registry = dispatch.downcast_ref::<Registry>()?;
+        let span_ref = registry.span(id)?;
+        for ancestor in span_ref.scope() {
+            let extensions = ancestor.extensions();
+            if let Some(storage) = extensions.get::<SpanFieldStorage>() {
+                if let Some((_, value)) = storage.0.iter().find(|(n, _)| *n == name) {
+                    if !value.is_empty() {
+                        return Some(value.clone());
+                    }
+                }
+            }
+        }
+        None
+    })
+    .flatten()
 }
 
 /// A no-op `FormatFields` — [`FlattenedFormatter`] handles all field

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -7,6 +7,16 @@ publish = false
 [lints]
 workspace = true
 
+[features]
+otel = [
+  "dep:opentelemetry",
+  "dep:opentelemetry-otlp",
+  "dep:opentelemetry-stdout",
+  "dep:opentelemetry_sdk",
+  "dep:tonic",
+  "dep:tracing-opentelemetry",
+]
+
 [dependencies]
 # interfaces
 fckn-gay-dns = { workspace = true, features = ["dummy"] }
@@ -23,12 +33,18 @@ axum-extra = { workspace = true, features = ["cookie"] }
 clap = { version = "4.5.60", features = ["derive"] }
 getrandom.workspace = true
 governor.workspace = true
+opentelemetry = { workspace = true, optional = true }
+opentelemetry-otlp = { workspace = true, optional = true }
+opentelemetry-stdout = { workspace = true, optional = true }
+opentelemetry_sdk = { workspace = true, optional = true }
 reqwest.workspace = true
 serde.workspace = true
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
+tonic = { workspace = true, optional = true }
 toml.workspace = true
 tower-http = { workspace = true, features = ["catch-panic", "fs", "trace"] }
 tower_governor = { workspace = true, features = ["tracing"] }
 tracing.workspace = true
+tracing-opentelemetry = { workspace = true, optional = true }
 tracing-subscriber.workspace = true
 uuid.workspace = true

--- a/server/src/error.rs
+++ b/server/src/error.rs
@@ -5,14 +5,17 @@ use axum::{
 };
 use serde::Serialize;
 
+use crate::telemetry;
+
 pub struct AppError {
     /// What the user sees — keep it silly but informative, never leak internals
     message: String,
     status: StatusCode,
     /// The real error chain for traces/logs — never shown to users
     internal: Option<anyhow::Error>,
-    /// The span that was active when this error was created, so handler fields
-    /// (like user=, record_name=, etc.) are still attached when we log it
+    /// The span that was active when this error was created, so the log line
+    /// gets the handler's fields (user, record, etc.) even though
+    /// `into_response()` runs after the handler span is dropped.
     origin_span: tracing::Span,
 }
 
@@ -39,19 +42,25 @@ impl AppError {
 #[derive(Serialize)]
 pub struct ErrorResponse {
     pub error: String,
+    pub trace_id: Option<String>,
 }
 
 impl IntoResponse for AppError {
     fn into_response(self) -> Response {
-        // Re-enter the span so structured fields from the handler are present
+        // Re-enter the span that was active when this error was created so the
+        // log line picks up handler fields (user, record, etc.) that would
+        // otherwise be lost because `into_response()` runs after the handler returns.
         let _guard = self.origin_span.enter();
 
+        // Log the error once — pass the raw error to tracing and let the
+        // formatter's `record_error` visitor walk the chain + deduplicate.
+        // Status goes as an event field so it folds into the `{}` block.
         let status = self.status.as_u16();
         if let Some(ref internal) = self.internal {
             let err: &(dyn std::error::Error + 'static) = internal.as_ref();
             match status {
-                400..=499 => tracing::warn!(error = err, status, "{}", self.message),
-                _ => tracing::error!(error = err, status, "{}", self.message),
+                400..=499 => tracing::warn!(error = err, status),
+                _ => tracing::error!(error = err, status),
             }
         } else {
             match status {
@@ -60,8 +69,11 @@ impl IntoResponse for AppError {
             }
         }
 
+        let trace_id = telemetry::current_trace_id();
+
         let body = ErrorResponse {
             error: self.message,
+            trace_id,
         };
 
         (self.status, Json(body)).into_response()

--- a/server/src/interfaces.rs
+++ b/server/src/interfaces.rs
@@ -1,4 +1,4 @@
-use std::{fmt::Display, path::Path, sync::Arc};
+use std::{collections::HashMap, fmt::Display, path::Path, sync::Arc};
 
 use anyhow::{Context, Result};
 use axum::extract::FromRef;
@@ -74,6 +74,11 @@ impl RateLimitConfig {
 #[derive(Clone, Debug)]
 pub struct LogFilter(EnvFilter);
 
+/// A simple max-level filter for the OTel tracing layer.
+/// Accepts level names: "trace", "debug", "info", "warn", "error", "off".
+#[derive(Clone, Copy, Debug)]
+pub struct TracingLevel(pub tracing::level_filters::LevelFilter);
+
 impl Default for LogFilter {
     fn default() -> Self {
         Self(EnvFilter::new("fckn_gay=debug,info"))
@@ -96,6 +101,24 @@ impl<'de> Deserialize<'de> for LogFilter {
         EnvFilter::try_new(&s)
             .map_err(serde::de::Error::custom)
             .map(LogFilter)
+    }
+}
+
+impl Default for TracingLevel {
+    fn default() -> Self {
+        Self(tracing::level_filters::LevelFilter::INFO)
+    }
+}
+
+impl<'de> Deserialize<'de> for TracingLevel {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let s = String::deserialize(deserializer)?;
+        s.parse::<tracing::level_filters::LevelFilter>()
+            .map(TracingLevel)
+            .map_err(serde::de::Error::custom)
     }
 }
 
@@ -164,6 +187,10 @@ pub struct Config {
     /// Optional Cloudflare Turnstile captcha for sign-up protection.
     /// If absent, sign-up works without captcha.
     pub turnstile: Option<TurnstileConfig>,
+    /// Tracing config — trust_incoming_spans is always available, OTel-specific
+    /// fields (backend, endpoint, headers) only compile with --features otel.
+    #[serde(default)]
+    pub tracing: TracingConfig,
 }
 
 impl Config {
@@ -186,7 +213,90 @@ impl Config {
             logging: LoggingConfig::default(),
             rate_limit: RateLimitConfig::default(),
             turnstile: None,
+            tracing: TracingConfig::default(),
         }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+pub struct TracingConfig {
+    /// Which tracing backend to use: "disabled", "stdout", or "otlp".
+    #[serde(default)]
+    pub provider: crate::telemetry::tracing_setup::TracingBackend,
+    /// When true, extract W3C trace context (traceparent/tracestate) from
+    /// incoming requests so the request span uses the caller's trace ID.
+    /// Only enable when the server sits behind a trusted proxy — accepting
+    /// trace IDs from the public internet lets anyone inject into your traces.
+    #[serde(default)]
+    pub trust_incoming_spans: bool,
+    /// How many hex characters of the trace ID to show in log output.
+    /// Applies to random IDs, traceparent extraction, and OTel trace IDs.
+    #[serde(default = "TracingConfig::default_trace_id_chars", deserialize_with = "deserialize_trace_id_chars")]
+    pub trace_id_chars: usize,
+    /// Max level for the OTel tracing layer, independent from the logging level.
+    /// e.g. gather traces at "debug" while only printing logs at "info".
+    #[serde(default)]
+    pub level: TracingLevel,
+    /// Provider-specific config for the OTLP backend.
+    #[serde(default)]
+    pub otlp: OtlpConfig,
+}
+
+/// OTLP-specific configuration — only used when `provider = "otlp"`.
+#[derive(Debug, Deserialize)]
+pub struct OtlpConfig {
+    #[serde(default = "OtlpConfig::default_endpoint")]
+    pub endpoint: String,
+    #[serde(default = "OtlpConfig::default_service_name")]
+    pub service_name: String,
+    /// Custom headers for authenticating to hosted collectors.
+    /// Values support all Secret formats: direct string, { env = "VAR" }, { file = "/path" }
+    #[serde(default)]
+    pub headers: HashMap<String, fckn_gay_secret::Secret>,
+}
+
+impl Default for TracingConfig {
+    fn default() -> Self {
+        Self {
+            provider: Default::default(),
+            trust_incoming_spans: false,
+            trace_id_chars: Self::default_trace_id_chars(),
+            level: TracingLevel::default(),
+            otlp: OtlpConfig::default(),
+        }
+    }
+}
+
+impl TracingConfig {
+    fn default_trace_id_chars() -> usize {
+        8
+    }
+}
+
+fn deserialize_trace_id_chars<'de, D: Deserializer<'de>>(d: D) -> Result<usize, D::Error> {
+    let n = usize::deserialize(d)?;
+    if n == 0 {
+        return Err(serde::de::Error::custom("trace_id_chars must be at least 1"));
+    }
+    Ok(n)
+}
+
+impl Default for OtlpConfig {
+    fn default() -> Self {
+        Self {
+            endpoint: Self::default_endpoint(),
+            service_name: Self::default_service_name(),
+            headers: HashMap::new(),
+        }
+    }
+}
+
+impl OtlpConfig {
+    fn default_endpoint() -> String {
+        "http://localhost:4317".to_string()
+    }
+    fn default_service_name() -> String {
+        "fckn-gay-server".to_string()
     }
 }
 

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -10,22 +10,31 @@ mod rate_limit;
 mod telemetry;
 mod user_routes;
 
-use std::{any::Any, net::SocketAddr, panic, path::PathBuf};
+use std::{net::SocketAddr, panic, path::PathBuf};
 
 use anyhow::{Context, Result};
-use axum::{body::Body, response::Response};
+use axum::{
+    Json,
+    body::Body,
+    response::{IntoResponse, Response},
+};
 use clap::Parser;
 use interfaces::{Config, Interfaces};
 use tower_http::{catch_panic::CatchPanicLayer, trace::TraceLayer};
 
-/// CatchPanicLayer handler — just returns the JSON response.
+use crate::error::ErrorResponse;
+
+/// CatchPanicLayer handler — returns JSON error with trace_id if available.
 /// Actual panic logging happens in the panic hook set in main().
-fn panic_response(_panic: Box<dyn Any + Send + 'static>) -> Response<Body> {
-    Response::builder()
-        .status(axum::http::StatusCode::INTERNAL_SERVER_ERROR)
-        .header("content-type", "application/json")
-        .body(Body::from(r#"{"error":"server ded RIP 💀"}"#))
-        .unwrap()
+fn panic_response(_panic: Box<dyn std::any::Any + Send + 'static>) -> Response<Body> {
+    (
+        axum::http::StatusCode::INTERNAL_SERVER_ERROR,
+        Json(ErrorResponse {
+            error: "server ded RIP 💀".to_string(),
+            trace_id: telemetry::current_trace_id(),
+        }),
+    )
+        .into_response()
 }
 
 #[derive(Parser, Debug)]
@@ -83,7 +92,38 @@ async fn main() -> Result<()> {
         Config::load_from_file(&args.config)?
     };
 
-    telemetry::logging::SubscriberBuilder::new(config.logging.clone()).init();
+    // Build the subscriber: fmt layer for logs, plus an optional OTel layer
+    // when compiled with --features otel and the config says so.
+    // OTel provider setup happens before init (it needs to be wired into the
+    // subscriber), so log messages are deferred and emitted after init.
+    let subscriber = telemetry::logging::SubscriberBuilder::new(config.logging.clone());
+
+    #[cfg(feature = "otel")]
+    let otel_output = telemetry::build_provider(&config.tracing);
+    #[cfg(feature = "otel")]
+    let otel_provider_handle = otel_output.provider.clone();
+    #[cfg(feature = "otel")]
+    let subscriber = if let Some(provider) = otel_output.provider {
+        subscriber.with_otel(provider, config.tracing.level.0)
+    } else {
+        subscriber
+    };
+
+    subscriber.init();
+
+    // Now that the subscriber is live, emit deferred OTel setup messages
+    #[cfg(feature = "otel")]
+    telemetry::log_deferred_messages(otel_output.messages);
+
+    #[cfg(not(feature = "otel"))]
+    if config.tracing.provider != telemetry::tracing_setup::TracingBackend::Disabled {
+        tracing::error!(
+            provider = ?config.tracing.provider,
+            "tracing provider is set but the `otel` feature isn't compiled in — \
+             distributed tracing will be disabled. Rebuild with `--features otel` \
+             or set provider = \"disabled\"."
+        );
+    }
 
     // Log panics with tracing so they get span context + structured fields
     panic::set_hook(Box::new(|panic_info| {
@@ -104,6 +144,9 @@ async fn main() -> Result<()> {
     }
 
     let address = config.address.clone();
+    let trust_incoming_spans = config.tracing.trust_incoming_spans;
+    let trace_id_chars = config.tracing.trace_id_chars;
+
     let interfaces = Interfaces::new(config)?;
 
     match args.command {
@@ -145,8 +188,23 @@ async fn main() -> Result<()> {
                 .context("Failed to bind to address")?;
             tracing::info!("starting server on http://{address}");
 
+            // Always-on request spans — OTel adds W3C context extraction on top
+            #[cfg(feature = "otel")]
             let trace_layer = TraceLayer::new_for_http()
-                .make_span_with(telemetry::tracing_setup::MakeRequestSpan)
+                .make_span_with(telemetry::tracing_setup::OtelMakeSpan {
+                    trust_incoming_spans,
+                    trace_id_chars,
+                })
+                .on_request(())
+                .on_response(telemetry::tracing_setup::RecordStatusOnResponse)
+                .on_failure(());
+
+            #[cfg(not(feature = "otel"))]
+            let trace_layer = TraceLayer::new_for_http()
+                .make_span_with(telemetry::tracing_setup::MakeRequestSpan {
+                    trust_incoming_spans,
+                    trace_id_chars,
+                })
                 .on_request(())
                 .on_response(telemetry::tracing_setup::RecordStatusOnResponse)
                 .on_failure(());
@@ -195,6 +253,13 @@ async fn main() -> Result<()> {
             )
             .await
             .context("Failed to start server")?;
+        }
+    }
+
+    #[cfg(feature = "otel")]
+    if let Some(provider) = otel_provider_handle {
+        if let Err(e) = provider.shutdown() {
+            eprintln!("OTel provider shutdown error: {e}");
         }
     }
 

--- a/server/src/telemetry/logging.rs
+++ b/server/src/telemetry/logging.rs
@@ -3,24 +3,97 @@ use tracing_subscriber::{Layer, layer::SubscriberExt, util::SubscriberInitExt};
 
 use crate::interfaces::LoggingConfig;
 
+// -- OTel filter --------------------------------------------------------------
+
+/// Per-layer filter for the OTel layer: drops all events (they're already
+/// captured by the fmt layer as log lines) and applies an independent level
+/// filter so you can e.g. gather traces at debug while only printing logs
+/// at info.
+#[cfg(feature = "otel")]
+struct OtelFilter {
+    max_level: tracing::level_filters::LevelFilter,
+}
+
+#[cfg(feature = "otel")]
+impl<S> tracing_subscriber::layer::Filter<S> for OtelFilter {
+    fn enabled(
+        &self,
+        meta: &tracing::Metadata<'_>,
+        _cx: &tracing_subscriber::layer::Context<'_, S>,
+    ) -> bool {
+        *meta.level() <= self.max_level
+    }
+
+    fn event_enabled(
+        &self,
+        _event: &tracing::Event<'_>,
+        _cx: &tracing_subscriber::layer::Context<'_, S>,
+    ) -> bool {
+        false
+    }
+}
+
+// -- Subscriber builder -------------------------------------------------------
+
 pub struct SubscriberBuilder {
     config: LoggingConfig,
+    #[cfg(feature = "otel")]
+    otel_provider: Option<opentelemetry_sdk::trace::SdkTracerProvider>,
+    #[cfg(feature = "otel")]
+    tracing_level: tracing::level_filters::LevelFilter,
 }
 
 impl SubscriberBuilder {
     pub fn new(config: LoggingConfig) -> Self {
-        Self { config }
+        Self {
+            config,
+            #[cfg(feature = "otel")]
+            otel_provider: None,
+            #[cfg(feature = "otel")]
+            tracing_level: tracing::level_filters::LevelFilter::INFO,
+        }
     }
 
+    #[cfg(feature = "otel")]
+    pub fn with_otel(
+        mut self,
+        provider: opentelemetry_sdk::trace::SdkTracerProvider,
+        level: tracing::level_filters::LevelFilter,
+    ) -> Self {
+        self.otel_provider = Some(provider);
+        self.tracing_level = level;
+        self
+    }
+
+    /// Install the global tracing subscriber. Call this exactly once.
     pub fn init(self) {
         let fmt_layer = tracing_subscriber::fmt::layer()
             .event_format(FlattenedFormatter::default())
             .fmt_fields(NullFields)
             .with_filter(self.config.level.into_env_filter());
 
-        tracing_subscriber::registry()
+        let registry = tracing_subscriber::registry()
             .with(SpanFieldLayer)
-            .with(fmt_layer)
-            .init();
+            .with(fmt_layer);
+
+        #[cfg(feature = "otel")]
+        {
+            use opentelemetry::trace::TracerProvider;
+
+            let otel_layer = self.otel_provider.map(|provider| {
+                tracing_opentelemetry::layer()
+                    .with_tracer(provider.tracer("fckn-gay-server"))
+                    .with_location(false)
+                    .with_threads(false)
+                    .with_tracked_inactivity(false)
+                    .with_filter(OtelFilter { max_level: self.tracing_level })
+            });
+            registry.with(otel_layer).init();
+        }
+
+        #[cfg(not(feature = "otel"))]
+        {
+            registry.init();
+        }
     }
 }

--- a/server/src/telemetry/mod.rs
+++ b/server/src/telemetry/mod.rs
@@ -1,2 +1,27 @@
 pub mod logging;
 pub mod tracing_setup;
+
+#[cfg(feature = "otel")]
+pub use tracing_setup::{build_provider, log_deferred_messages};
+
+/// Returns the current OTel trace ID as a hex string, or `None` if tracing
+/// is disabled / no active span.
+#[cfg(feature = "otel")]
+pub fn current_trace_id() -> Option<String> {
+    use opentelemetry::trace::TraceContextExt;
+    use tracing_opentelemetry::OpenTelemetrySpanExt;
+
+    let ctx = tracing::Span::current().context();
+    let span_ref = ctx.span();
+    let trace_id = span_ref.span_context().trace_id();
+    if trace_id == opentelemetry::trace::TraceId::INVALID {
+        None
+    } else {
+        Some(format!("{trace_id}"))
+    }
+}
+
+#[cfg(not(feature = "otel"))]
+pub fn current_trace_id() -> Option<String> {
+    fckn_gay_logging::get_current_span_field("trace_id")
+}

--- a/server/src/telemetry/tracing_setup.rs
+++ b/server/src/telemetry/tracing_setup.rs
@@ -1,23 +1,95 @@
-use std::time::Duration;
+use serde::Deserialize;
 
-/// Generates a request-level span with method and path fields.
-/// Status code is recorded after the response via `RecordStatusOnResponse`.
+#[derive(Deserialize, Default, Clone, Debug, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum TracingBackend {
+    #[default]
+    Disabled,
+    Stdout,
+    Otlp,
+}
+
+/// Parse W3C traceparent header, return the 32-hex-char trace ID.
+/// Format: `VV-TTTTTTTTTTTTTTTTTTTTTTTTTTTTTTTT-PPPPPPPPPPPPPPPP-FF`
+fn parse_traceparent_trace_id(value: &str) -> Option<&str> {
+    let bytes = value.as_bytes();
+    if bytes.len() < 55 {
+        return None;
+    }
+    if bytes[2] != b'-' || bytes[35] != b'-' || bytes[52] != b'-' {
+        return None;
+    }
+    // W3C spec: version ff is reserved and must be treated as invalid
+    if &value[0..2] == "ff" {
+        return None;
+    }
+    let trace_id = &value[3..35];
+    if !trace_id.bytes().all(|b| b.is_ascii_hexdigit()) {
+        return None;
+    }
+    if trace_id == "00000000000000000000000000000000" {
+        return None;
+    }
+    Some(trace_id)
+}
+
+/// Generate a random hex trace ID of the given length (capped at 32 chars).
+fn generate_random_trace_id(chars: usize) -> String {
+    let chars = chars.min(32);
+    let bytes_needed = (chars + 1) / 2;
+    let mut buf = [0u8; 16];
+    let _ = getrandom::fill(&mut buf[..bytes_needed]);
+    let mut s = String::with_capacity(chars);
+    for b in &buf[..bytes_needed] {
+        use std::fmt::Write;
+        write!(s, "{b:02x}").ok();
+    }
+    s.truncate(chars);
+    s
+}
+
+// -- Always-available request span + response recorder -------------------------
+
+/// Creates the root HTTP span for each request — always on, even without OTel.
 #[derive(Clone, Debug)]
-pub struct MakeRequestSpan;
+#[cfg_attr(feature = "otel", allow(dead_code))]
+pub struct MakeRequestSpan {
+    pub trust_incoming_spans: bool,
+    pub trace_id_chars: usize,
+}
 
 impl<B> tower_http::trace::MakeSpan<B> for MakeRequestSpan {
     fn make_span(&mut self, request: &axum::http::Request<B>) -> tracing::Span {
-        tracing::info_span!(
+        let span = tracing::info_span!(
             "request",
             method = %request.method(),
             path = %request.uri().path(),
+            trace_id = tracing::field::Empty,
             http.status_code = tracing::field::Empty,
             ok = tracing::field::Empty,
-        )
+        );
+
+        let chars = self.trace_id_chars;
+
+        // If we trust the caller, try to extract trace ID from traceparent header
+        let trace_id = if self.trust_incoming_spans {
+            request
+                .headers()
+                .get("traceparent")
+                .and_then(|v| v.to_str().ok())
+                .and_then(parse_traceparent_trace_id)
+                .map(|tid| tid[..chars.min(32)].to_owned())
+        } else {
+            None
+        }
+        .unwrap_or_else(|| generate_random_trace_id(chars));
+
+        span.record("trace_id", &trace_id);
+        span
     }
 }
 
-/// Records status code on the request span once the response is ready.
+/// Records `http.status_code` and `ok` on the span when the response is ready.
 #[derive(Clone, Debug)]
 pub struct RecordStatusOnResponse;
 
@@ -25,11 +97,301 @@ impl<B> tower_http::trace::OnResponse<B> for RecordStatusOnResponse {
     fn on_response(
         self,
         response: &axum::http::Response<B>,
-        _latency: Duration,
+        _latency: std::time::Duration,
         span: &tracing::Span,
     ) {
         let status = response.status().as_u16();
         span.record("http.status_code", status);
         span.record("ok", status < 400);
+    }
+}
+
+// -- OTel-only: W3C context extraction + provider lifecycle --------------------
+
+#[cfg(feature = "otel")]
+mod otel {
+    use opentelemetry::propagation::Extractor;
+    use opentelemetry_otlp::{WithExportConfig, WithTonicConfig};
+
+    use super::{TracingBackend, generate_random_trace_id};
+    use crate::interfaces::TracingConfig;
+
+    /// Wraps a SpanProcessor to strip `trace_id` from span attributes before
+    /// export. We record `trace_id` on request spans for the log formatter,
+    /// but OTel already carries the real trace ID in the span context — no
+    /// need to duplicate it as an attribute and clutter up Jaeger/Honeycomb/etc.
+    #[derive(Debug)]
+    struct StripTraceIdProcessor<P>(P);
+
+    impl<P: opentelemetry_sdk::trace::SpanProcessor> opentelemetry_sdk::trace::SpanProcessor
+        for StripTraceIdProcessor<P>
+    {
+        fn on_start(
+            &self,
+            span: &mut opentelemetry_sdk::trace::Span,
+            cx: &opentelemetry::Context,
+        ) {
+            self.0.on_start(span, cx);
+        }
+
+        fn on_end(&self, mut span: opentelemetry_sdk::trace::SpanData) {
+            span.attributes.retain(|kv| kv.key.as_str() != "trace_id");
+            self.0.on_end(span);
+        }
+
+        fn force_flush(&self) -> opentelemetry_sdk::error::OTelSdkResult {
+            self.0.force_flush()
+        }
+
+        fn shutdown(&self) -> opentelemetry_sdk::error::OTelSdkResult {
+            self.0.shutdown()
+        }
+    }
+
+    /// Messages collected during provider setup (before the tracing subscriber
+    /// is initialized), logged by main() after init.
+    pub struct ProviderOutput {
+        pub provider: Option<opentelemetry_sdk::trace::SdkTracerProvider>,
+        pub messages: Vec<(tracing::Level, String)>,
+    }
+
+    /// Builds the OTel tracer provider based on config. Returns `None` if tracing
+    /// is disabled, otherwise sets the global provider and returns it so we can
+    /// build a `tracing_opentelemetry` layer from it.
+    ///
+    /// Log messages are deferred — the subscriber isn't installed yet at this
+    /// point, so we return them for main() to emit after init.
+    pub fn build_provider(config: &TracingConfig) -> ProviderOutput {
+        let mut messages: Vec<(tracing::Level, String)> = Vec::new();
+
+        match config.provider {
+            TracingBackend::Disabled => {
+                messages.push((tracing::Level::INFO, "distributed tracing disabled".into()));
+                ProviderOutput {
+                    provider: None,
+                    messages,
+                }
+            }
+            TracingBackend::Stdout => {
+                if config.trust_incoming_spans {
+                    install_propagator(&mut messages);
+                }
+                let exporter = opentelemetry_stdout::SpanExporter::default();
+                let processor = opentelemetry_sdk::trace::SimpleSpanProcessor::new(exporter);
+
+                let provider = opentelemetry_sdk::trace::SdkTracerProvider::builder()
+                    .with_span_processor(StripTraceIdProcessor(processor))
+                    .with_resource(
+                        opentelemetry_sdk::Resource::builder()
+                            .with_service_name(config.otlp.service_name.clone())
+                            .build(),
+                    )
+                    .build();
+
+                opentelemetry::global::set_tracer_provider(provider.clone());
+                messages.push((
+                    tracing::Level::INFO,
+                    "OTel tracing enabled (stdout — for debugging only!)".into(),
+                ));
+                ProviderOutput {
+                    provider: Some(provider),
+                    messages,
+                }
+            }
+            TracingBackend::Otlp => {
+                if config.trust_incoming_spans {
+                    install_propagator(&mut messages);
+                }
+
+                let mut metadata = tonic::metadata::MetadataMap::new();
+                for (key, secret) in &config.otlp.headers {
+                    let Ok(k) =
+                        key.parse::<tonic::metadata::MetadataKey<tonic::metadata::Ascii>>()
+                    else {
+                        messages.push((
+                            tracing::Level::WARN,
+                            format!("invalid OTLP header name: {key}"),
+                        ));
+                        continue;
+                    };
+                    let Ok(v) = secret
+                        .expose()
+                        .parse::<tonic::metadata::MetadataValue<tonic::metadata::Ascii>>()
+                    else {
+                        messages.push((
+                            tracing::Level::WARN,
+                            format!("invalid OTLP header value for {key}"),
+                        ));
+                        continue;
+                    };
+                    metadata.insert(k, v);
+                }
+
+                let mut tonic_builder = opentelemetry_otlp::SpanExporter::builder()
+                    .with_tonic()
+                    .with_endpoint(&config.otlp.endpoint);
+                if !metadata.is_empty() {
+                    tonic_builder = tonic_builder.with_metadata(metadata);
+                }
+                let exporter = tonic_builder
+                    .build()
+                    .expect("failed to build OTLP exporter");
+                let processor =
+                    opentelemetry_sdk::trace::BatchSpanProcessor::builder(exporter).build();
+
+                let provider = opentelemetry_sdk::trace::SdkTracerProvider::builder()
+                    .with_span_processor(StripTraceIdProcessor(processor))
+                    .with_resource(
+                        opentelemetry_sdk::Resource::builder()
+                            .with_service_name(config.otlp.service_name.clone())
+                            .build(),
+                    )
+                    .build();
+
+                opentelemetry::global::set_tracer_provider(provider.clone());
+                messages.push((
+                    tracing::Level::INFO,
+                    format!("OTel tracing enabled (endpoint: {})", config.otlp.endpoint),
+                ));
+                ProviderOutput {
+                    provider: Some(provider),
+                    messages,
+                }
+            }
+        }
+    }
+
+    fn install_propagator(messages: &mut Vec<(tracing::Level, String)>) {
+        opentelemetry::global::set_text_map_propagator(
+            opentelemetry_sdk::propagation::TraceContextPropagator::new(),
+        );
+        messages.push((
+            tracing::Level::INFO,
+            "W3C trace context propagation enabled (trust_incoming_spans = true)".into(),
+        ));
+    }
+
+    /// Wrapper so we can impl `Extractor` on a borrowed `HeaderMap` without
+    /// pulling in `opentelemetry-http` as a direct dep.
+    struct HeaderMapExtractor<'a>(&'a axum::http::HeaderMap);
+
+    impl Extractor for HeaderMapExtractor<'_> {
+        fn get(&self, key: &str) -> Option<&str> {
+            self.0.get(key).and_then(|v| v.to_str().ok())
+        }
+
+        fn keys(&self) -> Vec<&str> {
+            self.0.keys().map(|k| k.as_str()).collect()
+        }
+    }
+
+    /// Wraps `MakeRequestSpan` with W3C trace context extraction from headers.
+    #[derive(Clone, Debug)]
+    pub struct OtelMakeSpan {
+        pub trust_incoming_spans: bool,
+        pub trace_id_chars: usize,
+    }
+
+    impl<B> tower_http::trace::MakeSpan<B> for OtelMakeSpan {
+        fn make_span(&mut self, request: &axum::http::Request<B>) -> tracing::Span {
+            // Only attach incoming context when we trust the caller
+            let _guard = self.trust_incoming_spans.then(|| {
+                let parent_cx = opentelemetry::global::get_text_map_propagator(|propagator| {
+                    propagator.extract(&HeaderMapExtractor(request.headers()))
+                });
+                parent_cx.attach()
+            });
+
+            let span = tracing::info_span!(
+                "request",
+                method = %request.method(),
+                path = %request.uri().path(),
+                trace_id = tracing::field::Empty,
+                http.status_code = tracing::field::Empty,
+                ok = tracing::field::Empty,
+            );
+
+            // OTel layer already assigned a trace ID during on_new_span
+            use opentelemetry::trace::TraceContextExt;
+            use tracing_opentelemetry::OpenTelemetrySpanExt;
+            let ctx = span.context();
+            let otel_tid = ctx.span().span_context().trace_id();
+            let tid_str = format!("{otel_tid}");
+            let chars = self.trace_id_chars.min(tid_str.len());
+            span.record("trace_id", &tid_str[..chars]);
+
+            // If the OTel trace ID is invalid (no OTel layer active), fall back
+            // to a random ID so we still get log correlation
+            if otel_tid == opentelemetry::trace::TraceId::INVALID {
+                span.record("trace_id", generate_random_trace_id(self.trace_id_chars));
+            }
+
+            span
+        }
+    }
+
+}
+
+#[cfg(feature = "otel")]
+pub use otel::*;
+
+/// Emit deferred log messages from OTel provider setup.
+/// Called from main() after the tracing subscriber is initialized.
+#[cfg(feature = "otel")]
+pub fn log_deferred_messages(messages: Vec<(tracing::Level, String)>) {
+    for (level, msg) in messages {
+        match level {
+            tracing::Level::ERROR => tracing::error!("{msg}"),
+            tracing::Level::WARN => tracing::warn!("{msg}"),
+            tracing::Level::INFO => tracing::info!("{msg}"),
+            tracing::Level::DEBUG => tracing::debug!("{msg}"),
+            tracing::Level::TRACE => tracing::trace!("{msg}"),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn valid_traceparent() {
+        let tp = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01";
+        assert_eq!(
+            parse_traceparent_trace_id(tp),
+            Some("4bf92f3577b34da6a3ce929d0e0e4736")
+        );
+    }
+
+    #[test]
+    fn all_zeros_invalid() {
+        let tp = "00-00000000000000000000000000000000-00f067aa0ba902b7-01";
+        assert_eq!(parse_traceparent_trace_id(tp), None);
+    }
+
+    #[test]
+    fn too_short() {
+        assert_eq!(parse_traceparent_trace_id("00-abc-def-01"), None);
+    }
+
+    #[test]
+    fn non_hex_chars() {
+        let tp = "00-zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz-00f067aa0ba902b7-01";
+        assert_eq!(parse_traceparent_trace_id(tp), None);
+    }
+
+    #[test]
+    fn version_ff_invalid() {
+        let tp = "ff-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01";
+        assert_eq!(parse_traceparent_trace_id(tp), None);
+    }
+
+    #[test]
+    fn random_trace_id_length() {
+        assert_eq!(generate_random_trace_id(8).len(), 8);
+        assert_eq!(generate_random_trace_id(16).len(), 16);
+        assert_eq!(generate_random_trace_id(32).len(), 32);
+        // capped at 32
+        assert_eq!(generate_random_trace_id(64).len(), 32);
     }
 }


### PR DESCRIPTION
## Summary
- Feature-gated OTel distributed tracing (`--features otel`) with three providers: disabled, stdout, otlp
- W3C traceparent extraction works even without OTel for free log correlation across services
- OTLP auth headers, independent OTel level filter, proper provider shutdown flush
- `current_trace_id()` reads from span scope so error JSON always has trace_id
- Config validation: `trace_id_chars >= 1`, traceparent version `ff` rejected per W3C spec
- `StripTraceIdProcessor` removes redundant `trace_id` attribute from OTel span exports
- `TracingConfig` compiles unconditionally — provider mismatch logs error instead of crashing

## Scope note
Outgoing trace propagation (injecting `traceparent` into outbound HTTP calls) is intentionally out of scope. Downstream services (Porkbun, Turnstile, etc.) are all third-party and won't produce traces for us anyway — this service participates as a trace leaf.

## Test plan
- [ ] Manual test with SigNoz

🤖 Generated with [Claude Code](https://claude.com/claude-code)